### PR TITLE
Auto hook up webpack watcher process for `devserver`

### DIFF
--- a/src/sentry_plugins/__init__.py
+++ b/src/sentry_plugins/__init__.py
@@ -3,5 +3,23 @@ from __future__ import absolute_import
 try:
     VERSION = __import__('pkg_resources') \
         .get_distribution('sentry-plugins').version
-except Exception, e:
+except Exception as e:
     VERSION = 'unknown'
+
+# Try to hook our webhook watcher into the rest of the watchers
+# iff this module is installed in editable mode.
+if 'site-packages' not in __file__:
+    import os
+
+    root = os.path.normpath(os.path.join(os.path.dirname(__file__), os.pardir, os.pardir))
+    node_modules = os.path.join(root, 'node_modules')
+
+    if os.path.isdir(node_modules):
+        from django.conf import settings
+        settings.SENTRY_WATCHERS += (
+            ('webpack.plugins', [
+                os.path.join(node_modules, '.bin', 'webpack'),
+                '--output-pathinfo', '--watch',
+                '--config={}'.format(os.path.join(root, 'webpack.config.js')),
+            ]),
+        )


### PR DESCRIPTION
@macqueen @dcramer

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/getsentry/sentry-plugins/25)
<!-- Reviewable:end -->
