### PR TITLE
[Slack] support optionally including culprit/project fields

### DIFF
--- a/src/sentry_plugins/slack/plugin.py
+++ b/src/sentry_plugins/slack/plugin.py
@@ -90,6 +90,20 @@ class SlackPlugin(CorePluginMixin, notify.NotificationPlugin):
             'type': 'bool',
             'required': False,
             'help': 'Include triggering rules with notifications.',
+        }, {
+            'name': 'exclude_project',
+            'label': 'Exclude Project Name',
+            'type': 'bool',
+            'default': False,
+            'required': False,
+            'help': 'Exclude project name with notifications.',
+        }, {
+            'name': 'exclude_culprit',
+            'label': 'Exclude Culprit',
+            'type': 'bool',
+            'default': False,
+            'required': False,
+            'help': 'Exclude culprit with notifications.',
         }]
 
     def color_for_event(self, event):
@@ -152,18 +166,18 @@ class SlackPlugin(CorePluginMixin, notify.NotificationPlugin):
 
         # They can be the same if there is no culprit
         # So we set culprit to an empty string instead of duplicating the text
-        if culprit and title != culprit:
+        if not self.get_option('exclude_culprit', project) and culprit and title != culprit:
             fields.append({
                 'title': 'Culprit',
                 'value': culprit,
                 'short': False,
             })
-
-        fields.append({
-            'title': 'Project',
-            'value': project_name,
-            'short': True,
-        })
+        if not self.get_option('exclude_project', project):
+            fields.append({
+                'title': 'Project',
+                'value': project_name,
+                'short': True,
+            })
 
         if self.get_option('include_rules', project):
             rules = []

--- a/tests/slack/test_plugin.py
+++ b/tests/slack/test_plugin.py
@@ -65,3 +65,79 @@ class SlackPluginTest(PluginTestCase):
                 },
             ],
         }
+
+    @responses.activate
+    def test_notification_without_culprit(self):
+        responses.add('POST', 'http://example.com/slack')
+        self.plugin.set_option('webhook', 'http://example.com/slack', self.project)
+        self.plugin.set_option('exclude_culprit', True, self.project)
+
+        group = self.create_group(message='Hello world', culprit='foo.bar')
+        event = self.create_event(group=group, message='Hello world', tags={'level': 'warning'})
+
+        rule = Rule.objects.create(project=self.project, label='my rule')
+
+        notification = Notification(event=event, rule=rule)
+
+        with self.options({'system.url-prefix': 'http://example.com'}):
+            self.plugin.notify(notification)
+
+        request = responses.calls[0].request
+        payload = json.loads(parse_qs(request.body)['payload'][0])
+        assert payload == {
+            'parse': 'none',
+            'username': 'Sentry',
+            'attachments': [
+                {
+                    'color': '#f18500',
+                    'fields': [
+                        {
+                            'short': True,
+                            'value': 'foo Bar',
+                            'title': 'Project'
+                        },
+                    ],
+                    'fallback': '[foo Bar] Hello world',
+                    'title': 'Hello world',
+                    'title_link': 'http://example.com/baz/bar/issues/1/',
+                },
+            ],
+        }
+
+    @responses.activate
+    def test_notification_without_project(self):
+        responses.add('POST', 'http://example.com/slack')
+        self.plugin.set_option('webhook', 'http://example.com/slack', self.project)
+        self.plugin.set_option('exclude_project', True, self.project)
+
+        group = self.create_group(message='Hello world', culprit='foo.bar')
+        event = self.create_event(group=group, message='Hello world', tags={'level': 'warning'})
+
+        rule = Rule.objects.create(project=self.project, label='my rule')
+
+        notification = Notification(event=event, rule=rule)
+
+        with self.options({'system.url-prefix': 'http://example.com'}):
+            self.plugin.notify(notification)
+
+        request = responses.calls[0].request
+        payload = json.loads(parse_qs(request.body)['payload'][0])
+        assert payload == {
+            'parse': 'none',
+            'username': 'Sentry',
+            'attachments': [
+                {
+                    'color': '#f18500',
+                    'fields': [
+                        {
+                            'short': False,
+                            'value': 'foo.bar',
+                            'title': 'Culprit',
+                        },
+                    ],
+                    'fallback': '[foo Bar] Hello world',
+                    'title': 'Hello world',
+                    'title_link': 'http://example.com/baz/bar/issues/1/',
+                },
+            ],
+        }


### PR DESCRIPTION
Hi @dcramer @macqueen, ptal? I would like to be able to not show the culprit/project fields in the Sentry slack notifications.