### PR TITLE
Support either of Sentry's URL patterns for HipChat card expansion.

### DIFF
--- a/src/sentry_plugins/hipchat_ac/views.py
+++ b/src/sentry_plugins/hipchat_ac/views.py
@@ -52,7 +52,7 @@ def get_link_regexp():
     pattern = get_link_pattern()
     if pattern not in _regexp_cache:
         _regexp_cache[pattern] = re.compile(pattern +
-            r'(?P<org>[^/]+)/(?P<proj>[^/]+)/group/'
+            r'(?P<org>[^/]+)/(?P<proj>[^/]+)/(?:group|issues)/'
             r'(?P<group>[^/]+)(/events/(?P<event>[^/]+)|/?)')
     return _regexp_cache[pattern]
 

--- a/tests/hipchat/test_views.py
+++ b/tests/hipchat/test_views.py
@@ -7,8 +7,8 @@ from sentry_plugins.hipchat_ac import views
 
 class HipchatPluginTest(PluginTestCase):
     def test_link_regex(self):
-        match_old = views.get_link_regexp().search(views.options.get('system.url-prefix') + "org/proj/group/123/events/456")
+        match_old = views.get_link_regexp().search(views.options.get('system.url-prefix') + "/org/proj/group/123/events/456")
         assert match_old is not None
 
-        match_new = views.get_link_regexp().search(views.options.get('system.url-prefix') + "org/proj/issues/123/events/456")
+        match_new = views.get_link_regexp().search(views.options.get('system.url-prefix') + "/org/proj/issues/123/events/456")
         assert match_new is not None

--- a/tests/hipchat/test_views.py
+++ b/tests/hipchat/test_views.py
@@ -8,8 +8,8 @@ from sentry_plugins.hipchat_ac import views
 class HipchatPluginTest(PluginTestCase):
     def test_link_regex(self):
         regex = views.get_link_regexp()
-        matchOld = regex.search(views.options.get('system.url-prefix') + "org/proj/group/123/events/456")
-        assert matchOld is not None
+        match_old = regex.search(views.options.get('system.url-prefix') + "org/proj/group/123/events/456")
+        assert match_old is not None
 
-        matchNew = regex.search(views.options.get('system.url-prefix') + "org/proj/issues/123/events/456")
-        assert matchNew is not None
+        match_new = regex.search(views.options.get('system.url-prefix') + "org/proj/issues/123/events/456")
+        assert match_new is not None

--- a/tests/hipchat/test_views.py
+++ b/tests/hipchat/test_views.py
@@ -1,0 +1,15 @@
+from __future__ import absolute_import
+
+from sentry.testutils import PluginTestCase
+
+from sentry_plugins.hipchat_ac import views
+
+
+class HipchatPluginTest(PluginTestCase):
+    def test_link_regex(self):
+        regex = views.get_link_regexp()
+        matchOld = regex.search(views.options.get('system.url-prefix') + "org/proj/group/123/events/456")
+        assert matchOld is not None
+
+        matchNew = regex.search(views.options.get('system.url-prefix') + "org/proj/issues/123/events/456")
+        assert matchNew is not None

--- a/tests/hipchat/test_views.py
+++ b/tests/hipchat/test_views.py
@@ -7,9 +7,8 @@ from sentry_plugins.hipchat_ac import views
 
 class HipchatPluginTest(PluginTestCase):
     def test_link_regex(self):
-        regex = views.get_link_regexp()
-        match_old = regex.search(views.options.get('system.url-prefix') + "org/proj/group/123/events/456")
+        match_old = views.get_link_regexp().search(views.options.get('system.url-prefix') + "org/proj/group/123/events/456")
         assert match_old is not None
 
-        match_new = regex.search(views.options.get('system.url-prefix') + "org/proj/issues/123/events/456")
+        match_new = views.get_link_regexp().search(views.options.get('system.url-prefix') + "org/proj/issues/123/events/456")
         assert match_new is not None


### PR DESCRIPTION
We have recently been setting up Sentry's HipChat Integration. One issue we found was that link expansion was not working correctly.

After digging around, we determined that that HipChat plugin expects URLs with a group parameter, but our Sentry is producing URLs with an issues parameter instead.

We were able to produce successful card expansions by simply swapping the "issues" in our URLs with "group".

It may make sense to rename this parameter throughout, but the simplest, most immediately backward compatible fix seems to be to simply allow either parameter in the link regex.