### PR TITLE
bitbucket commits and client

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -7,6 +7,7 @@ Version 8.17
 - Added Heroku for release tracking.
 - Added automatic commit-fetching for Heroku deploys.
 - Added Amazon SQS data forwarding.
+- Bitbucket commit integration
 
 Version 8.16
 ------------

--- a/setup.py
+++ b/setup.py
@@ -37,6 +37,7 @@ install_requires = [
     'python-dateutil',
     'PyJWT',
     'requests-oauthlib>=0.3.0'
+    'unidiff'
 ]
 
 

--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,7 @@ install_requires = [
     'boto3>=1.4.4,<1.5.0',
     'python-dateutil',
     'PyJWT',
-    'requests-oauthlib>=0.3.0'
+    'requests-oauthlib>=0.3.0',
     'unidiff'
 ]
 

--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,7 @@ install_requires = [
     'python-dateutil',
     'PyJWT',
     'requests-oauthlib>=0.3.0',
-    'unidiff'
+    'unidiff>=0.5.4'
 ]
 
 

--- a/src/sentry_plugins/bitbucket/client.py
+++ b/src/sentry_plugins/bitbucket/client.py
@@ -131,9 +131,23 @@ class BitbucketClient(object):
             ),
         )
 
+    def get_commit_filechanges(self, repo, sha):
+        # return api request that fetches last ~30 commits
+        # see https://developer.atlassian.com/bitbucket/api/2/reference/resource/repositories/%7Busername%7D/%7Brepo_slug%7D/commits/%7Brevision%7D
+        # using end_sha as parameter
+        patch_file =  self.request(
+            'GET',
+            '2.0',
+            '/repositories/{}/patch/{}'.format(
+                repo,
+                end_sha,
+            )
+        )
+
+
     def get_last_commits(self, repo, end_sha):
         # return api request that fetches last ~30 commits
-        # see https://developer.github.com/v3/repos/commits/#list-commits-on-a-repository
+        # see https://developer.atlassian.com/bitbucket/api/2/reference/resource/repositories/%7Busername%7D/%7Brepo_slug%7D/commits/%7Brevision%7D
         # using end_sha as parameter
         return self.request(
             'GET',
@@ -145,9 +159,8 @@ class BitbucketClient(object):
         )
 
     def compare_commits(self, repo, start_sha, end_sha):
-        # see https://developer.github.com/v3/repos/commits/#compare-two-commits
         # where start sha is oldest and end is most recent
-        # https://developer.atlassian.com/bitbucket/api/2/reference/resource/repositories/%7Busername%7D/%7Brepo_slug%7D/diff/%7Bspec%7D
+        # see https://developer.atlassian.com/bitbucket/api/2/reference/resource/repositories/%7Busername%7D/%7Brepo_slug%7D/commits/%7Brevision%7D
         data = self.request(
             'GET',
             '2.0',
@@ -158,9 +171,8 @@ class BitbucketClient(object):
         )
         commits = []
         for commit in data['values']:
-            # print( commit)
+            #TODO(maxbittker) fetch extra pages when this is paginated
             if commit['hash'] == start_sha:
                 break
             commits.append(commit)
-        print(commits)
         return commits

--- a/src/sentry_plugins/bitbucket/client.py
+++ b/src/sentry_plugins/bitbucket/client.py
@@ -66,6 +66,7 @@ class BitbucketClient(object):
             '/repositories/%s/issues/%s/comments' % (repo, issue_id),
             data=data,
         )
+
     # copied from github
     def create_hook(self, repo, data):
         return self.request(

--- a/src/sentry_plugins/bitbucket/client.py
+++ b/src/sentry_plugins/bitbucket/client.py
@@ -10,7 +10,7 @@ from requests_oauthlib import OAuth1
 
 
 class BitbucketClient(object):
-    API_URL = u'https://api.bitbucket.org/1.0'
+    API_URL = u'https://api.bitbucket.org/2.0'
 
     def __init__(self, auth):
         self.auth = auth
@@ -65,4 +65,47 @@ class BitbucketClient(object):
             'POST',
             '/repositories/%s/issues/%s/comments' % (repo, issue_id),
             data=data,
+        )
+    # copied from github
+    def create_hook(self, repo, data):
+        return self.request(
+            'POST',
+            '/repositories/{}/hooks'.format(
+                repo,
+            ),
+            data=data,
+        )
+
+    def delete_hook(self, repo, id):
+        return self.request(
+            'DELETE',
+            '/repositories/{}/hooks/{}'.format(
+                repo,
+                id,
+            ),
+        )
+
+    def get_last_commits(self, repo, end_sha):
+        # return api request that fetches last ~30 commits
+        # see https://developer.github.com/v3/repos/commits/#list-commits-on-a-repository
+        # using end_sha as parameter
+        return self.request(
+            'GET',
+            '/repositories/{}/commits/{}'.format(
+                repo,
+                end_sha,
+            )
+        )
+
+    def compare_commits(self, repo, start_sha, end_sha):
+        # see https://developer.github.com/v3/repos/commits/#compare-two-commits
+        # where start sha is oldest and end is most recent
+        # https://developer.atlassian.com/bitbucket/api/2/reference/resource/repositories/%7Busername%7D/%7Brepo_slug%7D/diff/%7Bspec%7D
+        return self.request(
+            'GET',
+            '/repositories/{}/diff/{}...{}'.format(
+                repo,
+                start_sha,
+                end_sha,
+            )
         )

--- a/src/sentry_plugins/bitbucket/client.py
+++ b/src/sentry_plugins/bitbucket/client.py
@@ -15,7 +15,7 @@ class BitbucketClient(object):
     def __init__(self, auth):
         self.auth = auth
 
-    def request(self, method, path, version, data=None, params=None):
+    def request(self, method, version, path, data=None, params=None):
         oauth = OAuth1(unicode(settings.BITBUCKET_CONSUMER_KEY),
                        unicode(settings.BITBUCKET_CONSUMER_SECRET),
                        self.auth.tokens['oauth_token'], self.auth.tokens['oauth_token_secret'],

--- a/src/sentry_plugins/bitbucket/client.py
+++ b/src/sentry_plugins/bitbucket/client.py
@@ -12,9 +12,9 @@ from requests_oauthlib import OAuth1
 class BitbucketClient(object):
     API_URL = u'https://api.bitbucket.org/'
 
-    def __init__(self, auth):
+    def __init__(self, auth=None):
         self.auth = auth
-        self.token = self.auth.tokens['oauth_token']
+        # self.token = self.auth.tokens['oauth_token']
 
     def _request2(self, method, path, data=None, params=None):
         headers = {
@@ -44,8 +44,8 @@ class BitbucketClient(object):
         return self._request(method, path, headers=headers, data=data, params=params)
 
     def request(self, method, version, path, data=None, params=None):
-        if version=='2.0':
-            return self._request2(method,path,data,params)
+        # if version=='2.0':
+            # return self._request2(method, path, data, params)
 
         oauth = OAuth1(unicode(settings.BITBUCKET_CONSUMER_KEY),
                        unicode(settings.BITBUCKET_CONSUMER_SECRET),
@@ -57,7 +57,7 @@ class BitbucketClient(object):
             resp = getattr(session, method.lower())(
                 url='%s%s%s' % (self.API_URL, version, path),
                 auth=oauth,
-                data=data,
+                json=data,
                 params=params,
             )
             resp.raise_for_status()
@@ -148,12 +148,19 @@ class BitbucketClient(object):
         # see https://developer.github.com/v3/repos/commits/#compare-two-commits
         # where start sha is oldest and end is most recent
         # https://developer.atlassian.com/bitbucket/api/2/reference/resource/repositories/%7Busername%7D/%7Brepo_slug%7D/diff/%7Bspec%7D
-        return self.request(
+        data = self.request(
             'GET',
             '2.0',
-            '/repositories/{}/diff/{}...{}'.format(
+            '/repositories/{}/commits/{}'.format(
                 repo,
-                start_sha,
-                end_sha,
+                end_sha
             )
         )
+        commits = []
+        for commit in data['values']:
+            # print( commit)
+            if commit['hash'] == start_sha:
+                break
+            commits.append(commit)
+        print(commits)
+        return commits

--- a/src/sentry_plugins/bitbucket/client.py
+++ b/src/sentry_plugins/bitbucket/client.py
@@ -10,7 +10,7 @@ from requests_oauthlib import OAuth1
 
 
 class BitbucketClient(object):
-    API_URL = u'https://api.bitbucket.org/2.0'
+    API_URL = u'https://api.bitbucket.org/1.0'
 
     def __init__(self, auth):
         self.auth = auth

--- a/src/sentry_plugins/bitbucket/client.py
+++ b/src/sentry_plugins/bitbucket/client.py
@@ -10,12 +10,12 @@ from requests_oauthlib import OAuth1
 
 
 class BitbucketClient(object):
-    API_URL = u'https://api.bitbucket.org/1.0'
+    API_URL = u'https://api.bitbucket.org/'
 
     def __init__(self, auth):
         self.auth = auth
 
-    def request(self, method, path, data=None, params=None):
+    def request(self, method, path, version, data=None, params=None):
         oauth = OAuth1(unicode(settings.BITBUCKET_CONSUMER_KEY),
                        unicode(settings.BITBUCKET_CONSUMER_SECRET),
                        self.auth.tokens['oauth_token'], self.auth.tokens['oauth_token_secret'],
@@ -24,7 +24,7 @@ class BitbucketClient(object):
         session = build_session()
         try:
             resp = getattr(session, method.lower())(
-                url='%s%s' % (self.API_URL, path),
+                url='%s%s%s' % (self.API_URL, version, path),
                 auth=oauth,
                 data=data,
                 params=params,
@@ -37,6 +37,7 @@ class BitbucketClient(object):
     def get_issue(self, repo, issue_id):
         return self.request(
             'GET',
+            '1.0',
             '/repositories/%s/issues/%s' % (repo, issue_id),
         )
 
@@ -49,6 +50,7 @@ class BitbucketClient(object):
         }
         return self.request(
             'POST',
+            '1.0',
             '/repositories/%s/issues' % (repo,),
             data=data
         )
@@ -56,6 +58,7 @@ class BitbucketClient(object):
     def search_issues(self, repo, query):
         return self.request(
             'GET',
+            '1.0',
             '/repositories/%s/issues' % (repo,),
             params={'search': query},
         )
@@ -63,6 +66,7 @@ class BitbucketClient(object):
     def create_comment(self, repo, issue_id, data):
         return self.request(
             'POST',
+            '1.0',
             '/repositories/%s/issues/%s/comments' % (repo, issue_id),
             data=data,
         )
@@ -71,6 +75,7 @@ class BitbucketClient(object):
     def create_hook(self, repo, data):
         return self.request(
             'POST',
+            '2.0',
             '/repositories/{}/hooks'.format(
                 repo,
             ),
@@ -80,6 +85,7 @@ class BitbucketClient(object):
     def delete_hook(self, repo, id):
         return self.request(
             'DELETE',
+            '2.0',
             '/repositories/{}/hooks/{}'.format(
                 repo,
                 id,
@@ -92,6 +98,7 @@ class BitbucketClient(object):
         # using end_sha as parameter
         return self.request(
             'GET',
+            '2.0',
             '/repositories/{}/commits/{}'.format(
                 repo,
                 end_sha,
@@ -104,6 +111,7 @@ class BitbucketClient(object):
         # https://developer.atlassian.com/bitbucket/api/2/reference/resource/repositories/%7Busername%7D/%7Brepo_slug%7D/diff/%7Bspec%7D
         return self.request(
             'GET',
+            '2.0',
             '/repositories/{}/diff/{}...{}'.format(
                 repo,
                 start_sha,

--- a/src/sentry_plugins/bitbucket/client.py
+++ b/src/sentry_plugins/bitbucket/client.py
@@ -22,7 +22,7 @@ class BitbucketClient(object):
         }
 
         session = build_session()
-        print(headers)
+        # print(headers)
         print('{}2.0{}'.format(self.API_URL, path))
         try:
             resp = getattr(session, method.lower())(

--- a/src/sentry_plugins/bitbucket/client.py
+++ b/src/sentry_plugins/bitbucket/client.py
@@ -36,8 +36,8 @@ class BitbucketClient(object):
             resp = getattr(session, method.lower())(
                 url='%s%s%s' % (self.API_URL, version, path),
                 auth=oauth,
-                data=(data if version == '1.0' else None)
-                json=(data if version == '2.0' else None)
+                data=(data if version == '1.0' else None),
+                json=(data if version == '2.0' else None),
                 params=params,
             )
             resp.raise_for_status()

--- a/src/sentry_plugins/bitbucket/client.py
+++ b/src/sentry_plugins/bitbucket/client.py
@@ -36,8 +36,8 @@ class BitbucketClient(object):
             resp = getattr(session, method.lower())(
                 url='%s%s%s' % (self.API_URL, version, path),
                 auth=oauth,
-                data= version == '1.0' and data,
-                json= version == '2.0' and data,
+                data=(data if version == '1.0' else None)
+                json=(data if version == '2.0' else None)
                 params=params,
             )
             resp.raise_for_status()

--- a/src/sentry_plugins/bitbucket/client.py
+++ b/src/sentry_plugins/bitbucket/client.py
@@ -36,7 +36,8 @@ class BitbucketClient(object):
             resp = getattr(session, method.lower())(
                 url='%s%s%s' % (self.API_URL, version, path),
                 auth=oauth,
-                json=data,
+                data= version == '1.0' and data,
+                json= version == '2.0' and data,
                 params=params,
             )
             resp.raise_for_status()

--- a/src/sentry_plugins/bitbucket/client.py
+++ b/src/sentry_plugins/bitbucket/client.py
@@ -78,8 +78,6 @@ class BitbucketClient(object):
             data=data,
         )
 
-    # copied from github
-
     def get_repo(self, repo):
         return self.request(
             'GET',
@@ -148,7 +146,7 @@ class BitbucketClient(object):
 
     def zip_commit_data(self, repo, commit_list):
         for commit in commit_list:
-            commit.update({"patch_set": self.get_commit_filechanges(repo, commit['hash'])})
+            commit.update({'patch_set': self.get_commit_filechanges(repo, commit['hash'])})
         return commit_list
 
     def get_last_commits(self, repo, end_sha):

--- a/src/sentry_plugins/bitbucket/client.py
+++ b/src/sentry_plugins/bitbucket/client.py
@@ -15,21 +15,18 @@ from requests_oauthlib import OAuth1
 class BitbucketClient(object):
     API_URL = u'https://api.bitbucket.org/'
 
-    def __init__(self, auth=None):
+    def __init__(self, auth):
         self.auth = auth
 
     def request(self, method, version, path, data=None, params=None, json=True):
 
-        try:
-            oauth = OAuth1(
-                six.text_type(settings.BITBUCKET_CONSUMER_KEY),
-                six.text_type(settings.BITBUCKET_CONSUMER_SECRET),
-                self.auth.tokens['oauth_token'],
-                self.auth.tokens['oauth_token_secret'],
-                signature_type='auth_header'
-            )
-        except KeyError as e:
-            oauth = None
+        oauth = OAuth1(
+            six.text_type(settings.BITBUCKET_CONSUMER_KEY),
+            six.text_type(settings.BITBUCKET_CONSUMER_SECRET),
+            self.auth.tokens['oauth_token'],
+            self.auth.tokens['oauth_token_secret'],
+            signature_type='auth_header'
+        )
 
         session = build_session()
         try:
@@ -185,7 +182,7 @@ class BitbucketClient(object):
         )
         commits = []
         for commit in data['values']:
-            # TODO(maxbittker) fetch extra pages (up to a max) when this is paginated
+            # TODO(maxbittker) fetch extra pages (up to a max) when this is paginated (more than 30 commits)
             if commit['hash'] == start_sha:
                 break
             commits.append(commit)

--- a/src/sentry_plugins/bitbucket/client.py
+++ b/src/sentry_plugins/bitbucket/client.py
@@ -19,10 +19,17 @@ class BitbucketClient(object):
         self.auth = auth
 
     def request(self, method, version, path, data=None, params=None, json=True):
-        oauth = OAuth1(six.text_type(settings.BITBUCKET_CONSUMER_KEY),
-                       six.text_type(settings.BITBUCKET_CONSUMER_SECRET),
-                       self.auth.tokens['oauth_token'], self.auth.tokens['oauth_token_secret'],
-                       signature_type='auth_header')
+
+        try:
+            oauth = OAuth1(
+                six.text_type(settings.BITBUCKET_CONSUMER_KEY),
+                six.text_type(settings.BITBUCKET_CONSUMER_SECRET),
+                self.auth.tokens['oauth_token'],
+                self.auth.tokens['oauth_token_secret'],
+                signature_type='auth_header'
+            )
+        except KeyError as e:
+            oauth = None
 
         session = build_session()
         try:

--- a/src/sentry_plugins/bitbucket/client.py
+++ b/src/sentry_plugins/bitbucket/client.py
@@ -18,36 +18,7 @@ class BitbucketClient(object):
     def __init__(self, auth=None):
         self.auth = auth
 
-    def _request2(self, method, path, data=None, params=None):
-        headers = {
-            'Authorization': 'token %s' % self.token,
-        }
-
-        session = build_session()
-
-        try:
-            resp = getattr(session, method.lower())(
-                url='{}2.0{}'.format(self.API_URL, path),
-                headers=headers,
-                json=data,
-                params=params,
-                allow_redirects=True,
-            )
-            resp.raise_for_status()
-        except HTTPError as e:
-            raise ApiError.from_response(e.response)
-
-        if resp.status_code == 204:
-            return {}
-
-        return resp.json()
-
-        return self._request(method, path, headers=headers, data=data, params=params)
-
     def request(self, method, version, path, data=None, params=None):
-        # if version=='2.0':
-            # return self._request2(method, path, data, params)
-
         oauth = OAuth1(six.text_type(settings.BITBUCKET_CONSUMER_KEY),
                        six.text_type(settings.BITBUCKET_CONSUMER_SECRET),
                        self.auth.tokens['oauth_token'], self.auth.tokens['oauth_token_secret'],
@@ -173,7 +144,7 @@ class BitbucketClient(object):
         )
         commits = []
         for commit in data['values']:
-            # TODO(maxbittker) fetch extra pages when this is paginated
+            # TODO(maxbittker) fetch extra pages (up to a max) when this is paginated
             if commit['hash'] == start_sha:
                 break
             commits.append(commit)

--- a/src/sentry_plugins/bitbucket/client.py
+++ b/src/sentry_plugins/bitbucket/client.py
@@ -130,9 +130,8 @@ class BitbucketClient(object):
         return file_changes
 
     def get_commit_filechanges(self, repo, sha):
-        # return api request that fetches last ~30 commits
-        # see https://developer.atlassian.com/bitbucket/api/2/reference/resource/repositories/%7Busername%7D/%7Brepo_slug%7D/commits/%7Brevision%7D
-        # using sha as parameter
+        # returns unidiff file
+
         diff_file = self.request(
             'GET',
             '2.0',
@@ -144,7 +143,6 @@ class BitbucketClient(object):
             params=None,
             json=False,
         )
-        #todo see if the data gets here and is a patch
         ps = PatchSet.from_string(diff_file)
         return self.transform_patchset(ps)
 
@@ -157,7 +155,7 @@ class BitbucketClient(object):
         # return api request that fetches last ~30 commits
         # see https://developer.atlassian.com/bitbucket/api/2/reference/resource/repositories/%7Busername%7D/%7Brepo_slug%7D/commits/%7Brevision%7D
         # using end_sha as parameter
-        data =  self.request(
+        data = self.request(
             'GET',
             '2.0',
             '/repositories/{}/commits/{}'.format(

--- a/src/sentry_plugins/bitbucket/endpoints/__init__.py
+++ b/src/sentry_plugins/bitbucket/endpoints/__init__.py
@@ -1,0 +1,1 @@
+from __future__ import absolute_import

--- a/src/sentry_plugins/bitbucket/endpoints/webhook.py
+++ b/src/sentry_plugins/bitbucket/endpoints/webhook.py
@@ -1,0 +1,289 @@
+from __future__ import absolute_import
+
+import dateutil.parser
+import hashlib
+import hmac
+import logging
+import six
+
+from django.db import IntegrityError, transaction
+from django.http import HttpResponse, Http404
+from django.utils.crypto import constant_time_compare
+from django.utils.decorators import method_decorator
+from django.views.decorators.csrf import csrf_exempt
+from django.views.generic import View
+from django.utils import timezone
+from simplejson import JSONDecodeError
+from sentry.models import (
+    Commit, CommitAuthor, CommitFileChange, Organization, OrganizationOption,
+    Repository, User
+)
+from sentry.plugins.providers import RepositoryProvider
+from sentry.utils import json
+
+from sentry_plugins.exceptions import ApiError
+from sentry_plugins.bitbucket.client import BitbucketClient
+
+logger = logging.getLogger('sentry.webhooks')
+
+
+def is_anonymous_email(email):
+    # todo(maxbittker)
+    return email[-25:] == '@users.noreply.bitbucket.com'
+
+
+def get_external_id(username):
+    # todo(maxbittker)
+    return 'bitbucket:%s' % username
+
+
+class Webhook(object):
+    def __call__(self, organization, event):
+        raise NotImplementedError
+
+
+class PushEventWebhook(Webhook):
+    # https://developer.github.com/v3/activity/events/types/#pushevent
+    def __call__(self, organization, event):
+        authors = {}
+
+        client = BitbucketClient()
+        gh_username_cache = {}
+
+        try:
+            repo = Repository.objects.get(
+                organization_id=organization.id,
+                provider='github',
+                external_id=six.text_type(event['repository']['id']),
+            )
+        except Repository.DoesNotExist:
+            raise Http404()
+
+        for commit in event['commits']:
+            if not commit['distinct']:
+                continue
+
+            if RepositoryProvider.should_ignore_commit(commit['message']):
+                continue
+
+            author_email = commit['author']['email']
+            if '@' not in author_email:
+                author_email = u'{}@localhost'.format(
+                    author_email[:65],
+                )
+            # try to figure out who anonymous emails are
+            elif is_anonymous_email(author_email):
+                gh_username = commit['author'].get('username')
+                # bot users don't have usernames
+                if gh_username:
+                    external_id = get_external_id(gh_username)
+                    if gh_username in gh_username_cache:
+                        author_email = gh_username_cache[gh_username] or author_email
+                    else:
+                        try:
+                            commit_author = CommitAuthor.objects.get(
+                                external_id=external_id,
+                                organization_id=organization.id,
+                            )
+                        except CommitAuthor.DoesNotExist:
+                            commit_author = None
+
+                        if commit_author is not None and not is_anonymous_email(commit_author.email):
+                            author_email = commit_author.email
+                            gh_username_cache[gh_username] = author_email
+                        else:
+                            try:
+                                gh_user = client.request_no_auth('GET', '/users/%s' % gh_username)
+                            except ApiError as exc:
+                                logger.exception(six.text_type(exc))
+                            else:
+                                # even if we can't find a user, set to none so we
+                                # don't re-query
+                                gh_username_cache[gh_username] = None
+                                try:
+                                    user = User.objects.filter(
+                                        social_auth__provider='github',
+                                        social_auth__uid=gh_user['id'],
+                                        org_memberships=organization,
+                                    )[0]
+                                except IndexError:
+                                    pass
+                                else:
+                                    author_email = user.email
+                                    gh_username_cache[gh_username] = author_email
+                                    if commit_author is not None:
+                                        try:
+                                            with transaction.atomic():
+                                                commit_author.update(
+                                                    email=author_email,
+                                                    external_id=external_id,
+                                                )
+                                        except IntegrityError:
+                                            pass
+
+                        if commit_author is not None:
+                            authors[author_email] = commit_author
+
+            # TODO(dcramer): we need to deal with bad values here, but since
+            # its optional, lets just throw it out for now
+            if len(author_email) > 75:
+                author = None
+            elif author_email not in authors:
+                authors[author_email] = author = CommitAuthor.objects.get_or_create(
+                    organization_id=organization.id,
+                    email=author_email,
+                    defaults={
+                        'name': commit['author']['name'][:128],
+                    }
+                )[0]
+
+                update_kwargs = {}
+
+                if author.name != commit['author']['name']:
+                    update_kwargs['name'] = commit['author']['name']
+
+                gh_username = commit['author'].get('username')
+                if gh_username:
+                    external_id = get_external_id(gh_username)
+                    if author.external_id != external_id and not is_anonymous_email(author.email):
+                        update_kwargs['external_id'] = external_id
+
+                if update_kwargs:
+                    try:
+                        with transaction.atomic():
+                            author.update(**update_kwargs)
+                    except IntegrityError:
+                        pass
+            else:
+                author = authors[author_email]
+
+            try:
+                with transaction.atomic():
+                    c = Commit.objects.create(
+                        repository_id=repo.id,
+                        organization_id=organization.id,
+                        key=commit['id'],
+                        message=commit['message'],
+                        author=author,
+                        date_added=dateutil.parser.parse(
+                            commit['timestamp'],
+                        ).astimezone(timezone.utc),
+                    )
+                    for fname in commit['added']:
+                        CommitFileChange.objects.create(
+                            organization_id=organization.id,
+                            commit=c,
+                            filename=fname,
+                            type='A',
+                        )
+                    for fname in commit['removed']:
+                        CommitFileChange.objects.create(
+                            organization_id=organization.id,
+                            commit=c,
+                            filename=fname,
+                            type='D',
+                        )
+                    for fname in commit['modified']:
+                        CommitFileChange.objects.create(
+                            organization_id=organization.id,
+                            commit=c,
+                            filename=fname,
+                            type='M',
+                        )
+            except IntegrityError:
+                pass
+
+
+class BitbucketWebhookEndpoint(View):
+    _handlers = {
+        'push': PushEventWebhook,
+    }
+
+    # https://developer.github.com/webhooks/
+    def get_handler(self, event_type):
+        return self._handlers.get(event_type)
+
+    def is_valid_signature(self, method, body, secret, signature):
+        if method == 'sha1':
+            mod = hashlib.sha1
+        else:
+            raise NotImplementedError('signature method %s is not supported' % (
+                method,
+            ))
+        expected = hmac.new(
+            key=secret.encode('utf-8'),
+            msg=body,
+            digestmod=mod,
+        ).hexdigest()
+        return constant_time_compare(expected, signature)
+
+    @method_decorator(csrf_exempt)
+    def dispatch(self, request, *args, **kwargs):
+        if request.method != 'POST':
+            return HttpResponse(status=405)
+
+        return super(BitbucketWebhookEndpoint, self).dispatch(request, *args, **kwargs)
+
+    def post(self, request, organization_id):
+        try:
+            organization = Organization.objects.get_from_cache(
+                id=organization_id,
+            )
+        except Organization.DoesNotExist:
+            logger.error('bitbucket.webhook.invalid-organization', extra={
+                'organization_id': organization_id,
+            })
+            return HttpResponse(status=400)
+
+        secret = OrganizationOption.objects.get_value(
+            organization=organization,
+            key='bitbucket:webhook_secret',
+        )
+        if secret is None:
+            logger.error('bitbucket.webhook.missing-secret', extra={
+                'organization_id': organization.id,
+            })
+            return HttpResponse(status=401)
+
+        body = six.binary_type(request.body)
+        if not body:
+            logger.error('bitbucket.webhook.missing-body', extra={
+                'organization_id': organization.id,
+            })
+            return HttpResponse(status=400)
+
+        try:
+            handler = self.get_handler(request.META['HTTP_X_GITHUB_EVENT'])
+        except KeyError:
+            logger.error('bitbucket.webhook.missing-event', extra={
+                'organization_id': organization.id,
+            })
+            return HttpResponse(status=400)
+
+        if not handler:
+            return HttpResponse(status=204)
+
+        try:
+            method, signature = request.META['HTTP_X_HUB_SIGNATURE'].split('=', 1)
+        except (KeyError, IndexError):
+            logger.error('bitbucket.webhook.missing-signature', extra={
+                'organization_id': organization.id,
+            })
+            return HttpResponse(status=400)
+
+        if not self.is_valid_signature(method, body, secret, signature):
+            logger.error('bitbucket.webhook.invalid-signature', extra={
+                'organization_id': organization.id,
+            })
+            return HttpResponse(status=401)
+
+        try:
+            event = json.loads(body.decode('utf-8'))
+        except JSONDecodeError:
+            logger.error('bitbucket.webhook.invalid-json', extra={
+                'organization_id': organization.id,
+            }, exc_info=True)
+            return HttpResponse(status=400)
+
+        handler()(organization, event)
+        return HttpResponse(status=204)

--- a/src/sentry_plugins/bitbucket/endpoints/webhook.py
+++ b/src/sentry_plugins/bitbucket/endpoints/webhook.py
@@ -30,12 +30,12 @@ BITBUCKET_IP_RANGE = ipaddress.ip_network(u'104.192.143.0/24')
 
 
 def is_anonymous_email(email):
-    # todo(maxbittker) investigate and improve behavior
-    return email[-25:] == '@users.noreply.bitbucket.com'
+    # TODO(maxbittker) investigate and improve behavior here
+    return email.endswith('@users.noreply.bitbucket.com')
 
 
 def get_external_id(username):
-    # todo(maxbittker) investigate and improve behavior
+    # TODO(maxbittker) investigate and improve behavior
     return 'bitbucket:%s' % username
 
 
@@ -54,7 +54,6 @@ class PushEventWebhook(Webhook):
     def __call__(self, organization, event):
         authors = {}
 
-        # client = BitbucketClient()
         try:
             repo = Repository.objects.get(
                 organization_id=organization.id,
@@ -63,7 +62,13 @@ class PushEventWebhook(Webhook):
             )
         except Repository.DoesNotExist:
             raise Http404()
-
+        
+        print(event['repository']['full_name'])
+        print(repo.config.get('name'))
+        if repo.config.get('name') != event['repository']['full_name']:
+            repo.config['name'] = event['repository']['full_name']
+            repo.save()
+        
         for change in event['push']['changes']:
             for commit in change['commits']:
                 if RepositoryProvider.should_ignore_commit(commit['message']):

--- a/src/sentry_plugins/bitbucket/endpoints/webhook.py
+++ b/src/sentry_plugins/bitbucket/endpoints/webhook.py
@@ -147,16 +147,6 @@ class BitbucketWebhookEndpoint(View):
             })
             return HttpResponse(status=400)
 
-        secret = OrganizationOption.objects.get_value(
-            organization=organization,
-            key='bitbucket:webhook_secret',
-        )
-        if secret is None:
-            logger.error('bitbucket.webhook.missing-secret', extra={
-                'organization_id': organization.id,
-            })
-            return HttpResponse(status=401)
-
         body = six.binary_type(request.body)
         if not body:
             logger.error('bitbucket.webhook.missing-body', extra={

--- a/src/sentry_plugins/bitbucket/endpoints/webhook.py
+++ b/src/sentry_plugins/bitbucket/endpoints/webhook.py
@@ -52,11 +52,11 @@ class PushEventWebhook(Webhook):
             )
         except Repository.DoesNotExist:
             raise Http404()
-        
+
         if repo.config.get('name') != event['repository']['full_name']:
             repo.config['name'] = event['repository']['full_name']
             repo.save()
-        
+
         for change in event['push']['changes']:
             for commit in change['commits']:
                 if RepositoryProvider.should_ignore_commit(commit['message']):

--- a/src/sentry_plugins/bitbucket/endpoints/webhook.py
+++ b/src/sentry_plugins/bitbucket/endpoints/webhook.py
@@ -100,31 +100,7 @@ class PushEventWebhook(Webhook):
                             ).astimezone(timezone.utc),
                         )
 
-                        # TODO(maxbittker) can't make these work until i save the auth token somewhere
-                        #
-                        # patch_set  = client.get_commit_filechanges(repo, commit['hash'])
-                        #
-                        # for patched_file in patch_set.added_files:
-                        #     CommitFileChange.objects.create(
-                        #         organization_id=organization.id,
-                        #         commit=c,
-                        #         filename=patched_file.path,
-                        #         type='A',
-                        #     )
-                        # for patched_file in patch_set.removed_files:
-                        #     CommitFileChange.objects.create(
-                        #         organization_id=organization.id,
-                        #         commit=c,
-                        #         filename=patched_file.path,
-                        #         type='D',
-                        #     )
-                        # for patched_file in path_set.modified_files:
-                        #     CommitFileChange.objects.create(
-                        #         organization_id=organization.id,
-                        #         commit=c,
-                        #         filename=patched_file.path,
-                        #         type='M',
-                        #     )
+
                 except IntegrityError:
                     pass
 

--- a/src/sentry_plugins/bitbucket/endpoints/webhook.py
+++ b/src/sentry_plugins/bitbucket/endpoints/webhook.py
@@ -18,8 +18,7 @@ from django.views.generic import View
 from django.utils import timezone
 from simplejson import JSONDecodeError
 from sentry.models import (
-    Commit, CommitAuthor, Organization, OrganizationOption,
-    Repository
+    Commit, CommitAuthor, Organization, Repository
 )
 from sentry.plugins.providers import RepositoryProvider
 from sentry.utils import json
@@ -28,6 +27,7 @@ logger = logging.getLogger('sentry.webhooks')
 
 # Bitbucket Cloud IP range: https://confluence.atlassian.com/bitbucket/manage-webhooks-735643732.html#Managewebhooks-trigger_webhookTriggeringwebhooks
 BITBUCKET_IP_RANGE = ipaddress.ip_network(u'104.192.143.0/24')
+
 
 def is_anonymous_email(email):
     # todo(maxbittker) investigate and improve behavior
@@ -101,7 +101,6 @@ class PushEventWebhook(Webhook):
                             ).astimezone(timezone.utc),
                         )
 
-
                 except IntegrityError:
                     pass
 
@@ -111,7 +110,6 @@ class BitbucketWebhookEndpoint(View):
         'repo:push': PushEventWebhook,
     }
 
-    # https://developer.github.com/webhooks/
     def get_handler(self, event_type):
         return self._handlers.get(event_type)
 
@@ -167,7 +165,7 @@ class BitbucketWebhookEndpoint(View):
 
         if not ipaddress.ip_address(six.text_type(request.META['REMOTE_ADDR'])) in BITBUCKET_IP_RANGE:
             logger.error('bitbucket.webhook.invalid-ip-range', extra={
-                    'organization_id': organization.id,
+                'organization_id': organization.id,
             })
             return HttpResponse(status=401)
 

--- a/src/sentry_plugins/bitbucket/endpoints/webhook.py
+++ b/src/sentry_plugins/bitbucket/endpoints/webhook.py
@@ -29,16 +29,6 @@ logger = logging.getLogger('sentry.webhooks')
 BITBUCKET_IP_RANGE = ipaddress.ip_network(u'104.192.143.0/24')
 
 
-def is_anonymous_email(email):
-    # TODO(maxbittker) investigate and improve behavior here
-    return email.endswith('@users.noreply.bitbucket.com')
-
-
-def get_external_id(username):
-    # TODO(maxbittker) investigate and improve behavior
-    return 'bitbucket:%s' % username
-
-
 class Webhook(object):
     def __call__(self, organization, event):
         raise NotImplementedError
@@ -73,8 +63,6 @@ class PushEventWebhook(Webhook):
                     continue
 
                 author_email = parse_raw_user(commit['author']['raw'])
-                if '@' not in author_email:
-                    author_email = u'{}@localhost'.format(author_email[:65])
 
                 # TODO(dcramer): we need to deal with bad values here, but since
                 # its optional, lets just throw it out for now

--- a/src/sentry_plugins/bitbucket/endpoints/webhook.py
+++ b/src/sentry_plugins/bitbucket/endpoints/webhook.py
@@ -1,8 +1,6 @@
 from __future__ import absolute_import
 
 import dateutil.parser
-import hashlib
-import hmac
 import logging
 import six
 import re
@@ -11,7 +9,6 @@ import ipaddress
 
 from django.db import IntegrityError, transaction
 from django.http import HttpResponse, Http404
-from django.utils.crypto import constant_time_compare
 from django.utils.decorators import method_decorator
 from django.views.decorators.csrf import csrf_exempt
 from django.views.generic import View
@@ -103,20 +100,6 @@ class BitbucketWebhookEndpoint(View):
 
     def get_handler(self, event_type):
         return self._handlers.get(event_type)
-
-    def is_valid_signature(self, method, body, secret, signature):
-        if method == 'sha1':
-            mod = hashlib.sha1
-        else:
-            raise NotImplementedError('signature method %s is not supported' % (
-                method,
-            ))
-        expected = hmac.new(
-            key=secret.encode('utf-8'),
-            msg=body,
-            digestmod=mod,
-        ).hexdigest()
-        return constant_time_compare(expected, signature)
 
     @method_decorator(csrf_exempt)
     def dispatch(self, request, *args, **kwargs):

--- a/src/sentry_plugins/bitbucket/endpoints/webhook.py
+++ b/src/sentry_plugins/bitbucket/endpoints/webhook.py
@@ -63,8 +63,6 @@ class PushEventWebhook(Webhook):
         except Repository.DoesNotExist:
             raise Http404()
         
-        print(event['repository']['full_name'])
-        print(repo.config.get('name'))
         if repo.config.get('name') != event['repository']['full_name']:
             repo.config['name'] = event['repository']['full_name']
             repo.save()

--- a/src/sentry_plugins/bitbucket/plugin.py
+++ b/src/sentry_plugins/bitbucket/plugin.py
@@ -2,6 +2,7 @@ from __future__ import absolute_import
 
 import logging
 import six
+import re
 
 from rest_framework.response import Response
 from uuid import uuid4
@@ -95,6 +96,9 @@ class BitbucketPlugin(CorePluginMixin, BitbucketMixin, IssuePlugin2):
                 plugin=self,
             )),
         ]
+
+    def get_url_module(self):
+        return 'sentry_plugins.bitbucket.urls'
 
     def is_configured(self, request, project, **kwargs):
         return bool(self.get_option('repo', project))
@@ -332,7 +336,7 @@ class BitbucketRepositoryProvider(BitbucketMixin, providers.RepositoryProvider):
                 'url': 'https://bitbucket.org/{}'.format(data['name']),
                 'config': {
                     'name': data['name'],
-                    'webhook_id': resp['id'],
+                    'webhook_id': resp['uuid'],
                 }
             }
 
@@ -377,4 +381,4 @@ class BitbucketRepositoryProvider(BitbucketMixin, providers.RepositoryProvider):
             except Exception as e:
                 self.raise_error(e)
             else:
-                return self._format_commits(repo, res['commits'])
+                return self._format_commits(repo, res)

--- a/src/sentry_plugins/bitbucket/plugin.py
+++ b/src/sentry_plugins/bitbucket/plugin.py
@@ -18,6 +18,7 @@ from sentry_plugins.base import CorePluginMixin
 from sentry_plugins.exceptions import ApiError, ApiUnauthorized
 
 from .client import BitbucketClient
+from .endpoints.webhook import parse_raw_user
 
 ISSUE_TYPES = (
     ('bug', 'Bug'),
@@ -319,7 +320,6 @@ class BitbucketRepositoryProvider(BitbucketMixin, providers.RepositoryProvider):
             raise NotImplementedError('Cannot create a repository anonymously')
 
         client = self.get_client(actor)
-        # import ipdb; ipdb.set_trace()
         try:
             resp = client.create_hook(data['name'], {
                 'description': 'sentry-bitbucket-repo-hook',
@@ -356,7 +356,7 @@ class BitbucketRepositoryProvider(BitbucketMixin, providers.RepositoryProvider):
         return [{
             'id': c['hash'],
             'repository': repo.name,
-            'author_email':re.search('(?<=<).*(?=>$)', c['author']['raw']),
+            'author_email': parse_raw_user(c['author']['raw']),
             'author_name': c['author']['user']['display_name'],
             'message': c['message'],
         } for c in commit_list]

--- a/src/sentry_plugins/bitbucket/plugin.py
+++ b/src/sentry_plugins/bitbucket/plugin.py
@@ -4,14 +4,18 @@ import logging
 import six
 
 from rest_framework.response import Response
+from uuid import uuid4
 
+from sentry.app import locks
 from sentry.exceptions import InvalidIdentity, PluginError
+from sentry.models import OrganizationOption
 from sentry.plugins.bases.issue2 import IssuePlugin2, IssueGroupActionEndpoint
+from sentry.plugins import providers
 from sentry.utils.http import absolute_uri
 
-from sentry.plugins import providers
 from sentry_plugins.base import CorePluginMixin
 from sentry_plugins.exceptions import ApiError, ApiUnauthorized
+
 from .client import BitbucketClient
 
 ISSUE_TYPES = (
@@ -207,6 +211,7 @@ class BitbucketPlugin(CorePluginMixin, IssuePlugin2):
         } for i in response.get('issues', [])]
 
         return Response({field: issues})
+
 
 class BitbucketRepositoryProvider(BitbucketPlugin, providers.RepositoryProvider):
     name = 'Bitbucket'

--- a/src/sentry_plugins/bitbucket/plugin.py
+++ b/src/sentry_plugins/bitbucket/plugin.py
@@ -354,11 +354,11 @@ class BitbucketRepositoryProvider(BitbucketMixin, providers.RepositoryProvider):
 
     def _format_commits(self, repo, commit_list):
         return [{
-            'id': c['sha'],
+            'id': c['hash'],
             'repository': repo.name,
-            'author_email': c['commit']['author'].get('email'),
-            'author_name': c['commit']['author'].get('name'),
-            'message': c['commit']['message'],
+            'author_email':re.search('(?<=<).*(?=>$)', c['author']['raw']),
+            'author_name': c['author']['user']['display_name'],
+            'message': c['message'],
         } for c in commit_list]
 
     def compare_commits(self, repo, start_sha, end_sha, actor=None):

--- a/src/sentry_plugins/bitbucket/plugin.py
+++ b/src/sentry_plugins/bitbucket/plugin.py
@@ -243,7 +243,6 @@ class BitbucketPlugin(CorePluginMixin, BitbucketMixin, IssuePlugin2):
         return [{
             'name': 'repo',
             'label': 'Repository Name',
-            'default': self.get_option('repo', project),
             'type': 'text',
             'placeholder': 'e.g. getsentry/sentry',
             'help': 'Enter your repository name, including the owner.',

--- a/src/sentry_plugins/bitbucket/plugin.py
+++ b/src/sentry_plugins/bitbucket/plugin.py
@@ -2,7 +2,6 @@ from __future__ import absolute_import
 
 import logging
 import six
-import re
 
 from rest_framework.response import Response
 from uuid import uuid4
@@ -48,6 +47,7 @@ ERR_UNAUTHORIZED = (
 ERR_404 = ('Bitbucket returned a 404. Please make sure that '
            'the repo exists, you have access to it, and it has '
            'issue tracking enabled.')
+
 
 class BitbucketMixin(object):
     def message_from_error(self, exc):
@@ -215,16 +215,6 @@ class BitbucketPlugin(CorePluginMixin, BitbucketMixin, IssuePlugin2):
         repo = self.get_option('repo', group.project)
         return 'https://bitbucket.org/%s/issue/%s/' % (repo, issue_id)
 
-    def get_configure_plugin_fields(self, request, project, **kwargs):
-        return [{
-            'name': 'repo',
-            'label': 'Repository Name',
-            'default': self.get_option('repo', project),
-            'type': 'text',
-            'placeholder': 'e.g. getsentry/sentry',
-            'help': 'Enter your repository name, including the owner.'
-        }]
-
     def view_autocomplete(self, request, group, **kwargs):
         field = request.GET.get('autocomplete_field')
         query = request.GET.get('autocomplete_query')
@@ -301,7 +291,6 @@ class BitbucketRepositoryProvider(BitbucketMixin, providers.RepositoryProvider):
         lock = locks.get('bitbucket:webhook-secret:{}'.format(organization.id),
                          duration=60)
         with lock.acquire():
-            # TODO(dcramer): get_or_create would be a useful native solution
             secret = OrganizationOption.objects.get_value(
                 organization=organization,
                 key='bitbucket:webhook_secret',

--- a/src/sentry_plugins/bitbucket/plugin.py
+++ b/src/sentry_plugins/bitbucket/plugin.py
@@ -56,7 +56,6 @@ class BitbucketMixin(object):
         elif isinstance(exc, ApiError):
             if exc.code == 404:
                 return ERR_404
-            # import ipdb; ipdb.set_trace()
             return ('Error Communicating with Bitbucket (HTTP %s): %s' % (
                 exc.code,
                 exc.json.get('message', 'unknown error') if exc.json else 'unknown error',

--- a/src/sentry_plugins/bitbucket/plugin.py
+++ b/src/sentry_plugins/bitbucket/plugin.py
@@ -348,6 +348,7 @@ class BitbucketRepositoryProvider(BitbucketMixin, providers.RepositoryProvider):
             'author_email': parse_raw_user(c['author']['raw']),
             'author_name': c['author']['user']['display_name'],
             'message': c['message'],
+            'patch_set': c.get('patch_set'),
         } for c in commit_list]
 
     def compare_commits(self, repo, start_sha, end_sha, actor=None):

--- a/src/sentry_plugins/bitbucket/testutils.py
+++ b/src/sentry_plugins/bitbucket/testutils.py
@@ -1,0 +1,295 @@
+# -*- coding: utf-8 -*-
+from __future__ import absolute_import
+
+
+# we keep this as a raw string as order matters for hmac signing
+PUSH_EVENT_EXAMPLE = b"""{
+    "push": {
+        "changes": [
+            {
+                "links": {
+                    "html": {
+                        "href": "https://bitbucket.org/maxbittker/newsdiffs/branches/compare/e0e377d186e4f0e937bdb487a23384fe002df649..8f5952f4dcffd7b311181d48eb0394b0cca21410"
+                    },
+                    "commits": {
+                        "href": "https://api.bitbucket.org/2.0/repositories/maxbittker/newsdiffs/commits?include=e0e377d186e4f0e937bdb487a23384fe002df649&exclude=8f5952f4dcffd7b311181d48eb0394b0cca21410"
+                    },
+                    "diff": {
+                        "href": "https://api.bitbucket.org/2.0/repositories/maxbittker/newsdiffs/diff/e0e377d186e4f0e937bdb487a23384fe002df649..8f5952f4dcffd7b311181d48eb0394b0cca21410"
+                    }
+                },
+                "commits": [
+                    {
+                        "links": {
+                            "approve": {
+                                "href": "https://api.bitbucket.org/2.0/repositories/maxbittker/newsdiffs/commit/e0e377d186e4f0e937bdb487a23384fe002df649/approve"
+                            },
+                            "statuses": {
+                                "href": "https://api.bitbucket.org/2.0/repositories/maxbittker/newsdiffs/commit/e0e377d186e4f0e937bdb487a23384fe002df649/statuses"
+                            },
+                            "comments": {
+                                "href": "https://api.bitbucket.org/2.0/repositories/maxbittker/newsdiffs/commit/e0e377d186e4f0e937bdb487a23384fe002df649/comments"
+                            },
+                            "self": {
+                                "href": "https://api.bitbucket.org/2.0/repositories/maxbittker/newsdiffs/commit/e0e377d186e4f0e937bdb487a23384fe002df649"
+                            },
+                            "patch": {
+                                "href": "https://api.bitbucket.org/2.0/repositories/maxbittker/newsdiffs/patch/e0e377d186e4f0e937bdb487a23384fe002df649"
+                            },
+                            "html": {
+                                "href": "https://bitbucket.org/maxbittker/newsdiffs/commits/e0e377d186e4f0e937bdb487a23384fe002df649"
+                            },
+                            "diff": {
+                                "href": "https://api.bitbucket.org/2.0/repositories/maxbittker/newsdiffs/diff/e0e377d186e4f0e937bdb487a23384fe002df649"
+                            }
+                        },
+                        "date": "2017-05-24T01:05:47+00:00",
+                        "hash": "e0e377d186e4f0e937bdb487a23384fe002df649",
+                        "parents": [
+                            {
+                                "type": "commit",
+                                "links": {
+                                    "html": {
+                                        "href": "https://bitbucket.org/maxbittker/newsdiffs/commits/8f5952f4dcffd7b311181d48eb0394b0cca21410"
+                                    },
+                                    "self": {
+                                        "href": "https://api.bitbucket.org/2.0/repositories/maxbittker/newsdiffs/commit/8f5952f4dcffd7b311181d48eb0394b0cca21410"
+                                    }
+                                },
+                                "hash": "8f5952f4dcffd7b311181d48eb0394b0cca21410"
+                            }
+                        ],
+                        "type": "commit",
+                        "message": "README.md edited online with Bitbucket",
+                        "author": {
+                            "type": "author",
+                            "user": {
+                                "type": "user",
+                                "display_name": "Max Bittker",
+                                "uuid": "{b128e0f6-196a-4dde-b72d-f42abc6dc239}",
+                                "username": "maxbittker",
+                                "links": {
+                                    "html": {
+                                        "href": "https://bitbucket.org/maxbittker/"
+                                    },
+                                    "avatar": {
+                                        "href": "https://bitbucket.org/account/maxbittker/avatar/32/"
+                                    },
+                                    "self": {
+                                        "href": "https://api.bitbucket.org/2.0/users/maxbittker"
+                                    }
+                                }
+                            },
+                            "raw": "Max Bittker <max@getsentry.com>"
+                        }
+                    }
+                ],
+                "old": {
+                    "type": "branch",
+                    "links": {
+                        "html": {
+                            "href": "https://bitbucket.org/maxbittker/newsdiffs/branch/master"
+                        },
+                        "commits": {
+                            "href": "https://api.bitbucket.org/2.0/repositories/maxbittker/newsdiffs/commits/master"
+                        },
+                        "self": {
+                            "href": "https://api.bitbucket.org/2.0/repositories/maxbittker/newsdiffs/refs/branches/master"
+                        }
+                    },
+                    "target": {
+                        "links": {
+                            "html": {
+                                "href": "https://bitbucket.org/maxbittker/newsdiffs/commits/8f5952f4dcffd7b311181d48eb0394b0cca21410"
+                            },
+                            "self": {
+                                "href": "https://api.bitbucket.org/2.0/repositories/maxbittker/newsdiffs/commit/8f5952f4dcffd7b311181d48eb0394b0cca21410"
+                            }
+                        },
+                        "date": "2017-05-19T22:53:22+00:00",
+                        "hash": "8f5952f4dcffd7b311181d48eb0394b0cca21410",
+                        "parents": [
+                            {
+                                "type": "commit",
+                                "links": {
+                                    "html": {
+                                        "href": "https://bitbucket.org/maxbittker/newsdiffs/commits/1cdfa36e62e615cdc73a1d5fcff1c706965b186d"
+                                    },
+                                    "self": {
+                                        "href": "https://api.bitbucket.org/2.0/repositories/maxbittker/newsdiffs/commit/1cdfa36e62e615cdc73a1d5fcff1c706965b186d"
+                                    }
+                                },
+                                "hash": "1cdfa36e62e615cdc73a1d5fcff1c706965b186d"
+                            }
+                        ],
+                        "type": "commit",
+                        "message": "README.md edited online with Bitbucket",
+                        "author": {
+                            "type": "author",
+                            "user": {
+                                "type": "user",
+                                "display_name": "Max Bittker",
+                                "uuid": "{b128e0f6-196a-4dde-b72d-f42abc6dc239}",
+                                "username": "maxbittker",
+                                "links": {
+                                    "html": {
+                                        "href": "https://bitbucket.org/maxbittker/"
+                                    },
+                                    "avatar": {
+                                        "href": "https://bitbucket.org/account/maxbittker/avatar/32/"
+                                    },
+                                    "self": {
+                                        "href": "https://api.bitbucket.org/2.0/users/maxbittker"
+                                    }
+                                }
+                            },
+                            "raw": "Max Bittker <max@getsentry.com>"
+                        }
+                    },
+                    "name": "master"
+                },
+                "truncated": false,
+                "new": {
+                    "type": "branch",
+                    "links": {
+                        "html": {
+                            "href": "https://bitbucket.org/maxbittker/newsdiffs/branch/master"
+                        },
+                        "commits": {
+                            "href": "https://api.bitbucket.org/2.0/repositories/maxbittker/newsdiffs/commits/master"
+                        },
+                        "self": {
+                            "href": "https://api.bitbucket.org/2.0/repositories/maxbittker/newsdiffs/refs/branches/master"
+                        }
+                    },
+                    "target": {
+                        "links": {
+                            "html": {
+                                "href": "https://bitbucket.org/maxbittker/newsdiffs/commits/e0e377d186e4f0e937bdb487a23384fe002df649"
+                            },
+                            "self": {
+                                "href": "https://api.bitbucket.org/2.0/repositories/maxbittker/newsdiffs/commit/e0e377d186e4f0e937bdb487a23384fe002df649"
+                            }
+                        },
+                        "date": "2017-05-24T01:05:47+00:00",
+                        "hash": "e0e377d186e4f0e937bdb487a23384fe002df649",
+                        "parents": [
+                            {
+                                "type": "commit",
+                                "links": {
+                                    "html": {
+                                        "href": "https://bitbucket.org/maxbittker/newsdiffs/commits/8f5952f4dcffd7b311181d48eb0394b0cca21410"
+                                    },
+                                    "self": {
+                                        "href": "https://api.bitbucket.org/2.0/repositories/maxbittker/newsdiffs/commit/8f5952f4dcffd7b311181d48eb0394b0cca21410"
+                                    }
+                                },
+                                "hash": "8f5952f4dcffd7b311181d48eb0394b0cca21410"
+                            }
+                        ],
+                        "type": "commit",
+                        "message": "README.md edited online with Bitbucket",
+                        "author": {
+                            "type": "author",
+                            "user": {
+                                "type": "user",
+                                "display_name": "Max Bittker",
+                                "uuid": "{b128e0f6-196a-4dde-b72d-f42abc6dc239}",
+                                "username": "maxbittker",
+                                "links": {
+                                    "html": {
+                                        "href": "https://bitbucket.org/maxbittker/"
+                                    },
+                                    "avatar": {
+                                        "href": "https://bitbucket.org/account/maxbittker/avatar/32/"
+                                    },
+                                    "self": {
+                                        "href": "https://api.bitbucket.org/2.0/users/maxbittker"
+                                    }
+                                }
+                            },
+                            "raw": "Max Bittker <max@getsentry.com>"
+                        }
+                    },
+                    "name": "master"
+                },
+                "created": false,
+                "forced": false,
+                "closed": false
+            }
+        ]
+    },
+    "repository": {
+        "links": {
+            "html": {
+                "href": "https://bitbucket.org/maxbittker/newsdiffs"
+            },
+            "avatar": {
+                "href": "https://bitbucket.org/maxbittker/newsdiffs/avatar/32/"
+            },
+            "self": {
+                "href": "https://api.bitbucket.org/2.0/repositories/maxbittker/newsdiffs"
+            }
+        },
+        "full_name": "maxbittker/newsdiffs",
+        "scm": "git",
+        "uuid": "{c78dfb25-7882-4550-97b1-4e0d38f32859}",
+        "type": "repository",
+        "is_private": false,
+        "owner": {
+            "type": "user",
+            "display_name": "Max Bittker",
+            "uuid": "{b128e0f6-196a-4dde-b72d-f42abc6dc239}",
+            "username": "maxbittker",
+            "links": {
+                "html": {
+                    "href": "https://bitbucket.org/maxbittker/"
+                },
+                "avatar": {
+                    "href": "https://bitbucket.org/account/maxbittker/avatar/32/"
+                },
+                "self": {
+                    "href": "https://api.bitbucket.org/2.0/users/maxbittker"
+                }
+            }
+        },
+        "name": "newsdiffs",
+        "website": ""
+    },
+    "actor": {
+        "type": "user",
+        "display_name": "Max Bittker",
+        "uuid": "{b128e0f6-196a-4dde-b72d-f42abc6dc239}",
+        "username": "maxbittker",
+        "links": {
+            "html": {
+                "href": "https://bitbucket.org/maxbittker/"
+            },
+            "avatar": {
+                "href": "https://bitbucket.org/account/maxbittker/avatar/32/"
+            },
+            "self": {
+                "href": "https://api.bitbucket.org/2.0/users/maxbittker"
+            }
+        }
+    }
+}
+"""
+
+COMPARE_COMMITS_EXAMPLE  = b"""{
+"pagelen": 30,
+ "values":
+     [{"hash": "e18e4e72de0d824edfbe0d73efe34cbd0d01d301",
+      "repository": {"links": {"self": {"href": "https://api.bitbucket.org/2.0/repositories/maxbittker/newsdiffs"}, "html": {"href": "https://bitbucket.org/maxbittker/newsdiffs"}, "avatar": {"href": "https://bitbucket.org/maxbittker/newsdiffs/avatar/32/"}}, "type": "repository", "name": "newsdiffs", "full_name": "maxbittker/newsdiffs", "uuid": "{c78dfb25-7882-4550-97b1-4e0d38f32859}"}, "links": {"self": {"href": "https://api.bitbucket.org/2.0/repositories/maxbittker/newsdiffs/commit/e18e4e72de0d824edfbe0d73efe34cbd0d01d301"}, "comments": {"href": "https://api.bitbucket.org/2.0/repositories/maxbittker/newsdiffs/commit/e18e4e72de0d824edfbe0d73efe34cbd0d01d301/comments"}, "patch": {"href": "https://api.bitbucket.org/2.0/repositories/maxbittker/newsdiffs/patch/e18e4e72de0d824edfbe0d73efe34cbd0d01d301"}, "html": {"href": "https://bitbucket.org/maxbittker/newsdiffs/commits/e18e4e72de0d824edfbe0d73efe34cbd0d01d301"}, "diff": {"href": "https://api.bitbucket.org/2.0/repositories/maxbittker/newsdiffs/diff/e18e4e72de0d824edfbe0d73efe34cbd0d01d301"}, "approve": {"href": "https://api.bitbucket.org/2.0/repositories/maxbittker/newsdiffs/commit/e18e4e72de0d824edfbe0d73efe34cbd0d01d301/approve"}, "statuses": {"href": "https://api.bitbucket.org/2.0/repositories/maxbittker/newsdiffs/commit/e18e4e72de0d824edfbe0d73efe34cbd0d01d301/statuses"}}, "author": {"raw": "Max Bittker <max@getsentry.com>", "type": "author", "user": {"username": "maxbittker", "display_name": "Max Bittker", "type": "user", "uuid": "{b128e0f6-196a-4dde-b72d-f42abc6dc239}", "links": {"self": {"href": "https://api.bitbucket.org/2.0/users/maxbittker"}, "html": {"href": "https://bitbucket.org/maxbittker/"}, "avatar": {"href": "https://bitbucket.org/account/maxbittker/avatar/32/"}}}}, "parents": [{"hash": "26de9b63d09aa9c787e899f149c672023e292925", "type": "commit", "links": {"self": {"href": "https://api.bitbucket.org/2.0/repositories/maxbittker/newsdiffs/commit/26de9b63d09aa9c787e899f149c672023e292925"}, "html": {"href": "https://bitbucket.org/maxbittker/newsdiffs/commits/26de9b63d09aa9c787e899f149c672023e292925"}}}], "date": "2017-05-16T23:21:40+00:00", "message": "README.md edited online with Bitbucket", "type": "commit"}],
+  "next": "https://api.bitbucket.org/2.0/repositories/maxbittker/newsdiffs/commits/e18e4e72de0d824edfbe0d73efe34cbd0d01d301?page=2"
+}
+"""
+
+GET_LAST_COMMITS_EXAMPLE = b"""{
+"pagelen": 30,
+ "values":
+     [{"hash": "e18e4e72de0d824edfbe0d73efe34cbd0d01d301",
+      "repository": {"links": {"self": {"href": "https://api.bitbucket.org/2.0/repositories/maxbittker/newsdiffs"}, "html": {"href": "https://bitbucket.org/maxbittker/newsdiffs"}, "avatar": {"href": "https://bitbucket.org/maxbittker/newsdiffs/avatar/32/"}}, "type": "repository", "name": "newsdiffs", "full_name": "maxbittker/newsdiffs", "uuid": "{c78dfb25-7882-4550-97b1-4e0d38f32859}"}, "links": {"self": {"href": "https://api.bitbucket.org/2.0/repositories/maxbittker/newsdiffs/commit/e18e4e72de0d824edfbe0d73efe34cbd0d01d301"}, "comments": {"href": "https://api.bitbucket.org/2.0/repositories/maxbittker/newsdiffs/commit/e18e4e72de0d824edfbe0d73efe34cbd0d01d301/comments"}, "patch": {"href": "https://api.bitbucket.org/2.0/repositories/maxbittker/newsdiffs/patch/e18e4e72de0d824edfbe0d73efe34cbd0d01d301"}, "html": {"href": "https://bitbucket.org/maxbittker/newsdiffs/commits/e18e4e72de0d824edfbe0d73efe34cbd0d01d301"}, "diff": {"href": "https://api.bitbucket.org/2.0/repositories/maxbittker/newsdiffs/diff/e18e4e72de0d824edfbe0d73efe34cbd0d01d301"}, "approve": {"href": "https://api.bitbucket.org/2.0/repositories/maxbittker/newsdiffs/commit/e18e4e72de0d824edfbe0d73efe34cbd0d01d301/approve"}, "statuses": {"href": "https://api.bitbucket.org/2.0/repositories/maxbittker/newsdiffs/commit/e18e4e72de0d824edfbe0d73efe34cbd0d01d301/statuses"}}, "author": {"raw": "Max Bittker <max@getsentry.com>", "type": "author", "user": {"username": "maxbittker", "display_name": "Max Bittker", "type": "user", "uuid": "{b128e0f6-196a-4dde-b72d-f42abc6dc239}", "links": {"self": {"href": "https://api.bitbucket.org/2.0/users/maxbittker"}, "html": {"href": "https://bitbucket.org/maxbittker/"}, "avatar": {"href": "https://bitbucket.org/account/maxbittker/avatar/32/"}}}}, "parents": [{"hash": "26de9b63d09aa9c787e899f149c672023e292925", "type": "commit", "links": {"self": {"href": "https://api.bitbucket.org/2.0/repositories/maxbittker/newsdiffs/commit/26de9b63d09aa9c787e899f149c672023e292925"}, "html": {"href": "https://bitbucket.org/maxbittker/newsdiffs/commits/26de9b63d09aa9c787e899f149c672023e292925"}}}], "date": "2017-05-16T23:21:40+00:00", "message": "README.md edited online with Bitbucket", "type": "commit"}],
+  "next": "https://api.bitbucket.org/2.0/repositories/maxbittker/newsdiffs/commits/e18e4e72de0d824edfbe0d73efe34cbd0d01d301?page=2"
+}
+"""

--- a/src/sentry_plugins/bitbucket/testutils.py
+++ b/src/sentry_plugins/bitbucket/testutils.py
@@ -2,7 +2,6 @@
 from __future__ import absolute_import
 
 
-# we keep this as a raw string as order matters for hmac signing
 PUSH_EVENT_EXAMPLE = b"""{
     "push": {
         "changes": [

--- a/src/sentry_plugins/bitbucket/testutils.py
+++ b/src/sentry_plugins/bitbucket/testutils.py
@@ -276,7 +276,7 @@ PUSH_EVENT_EXAMPLE = b"""{
 }
 """
 
-COMPARE_COMMITS_EXAMPLE  = b"""{
+COMPARE_COMMITS_EXAMPLE = b"""{
 "pagelen": 30,
  "values":
      [{"hash": "e18e4e72de0d824edfbe0d73efe34cbd0d01d301",

--- a/src/sentry_plugins/bitbucket/urls.py
+++ b/src/sentry_plugins/bitbucket/urls.py
@@ -1,0 +1,10 @@
+from __future__ import absolute_import
+
+from django.conf.urls import patterns, url
+
+from .endpoints.webhook import BitbucketWebhookEndpoint
+
+urlpatterns = patterns(
+    '',
+    url(r'^organizations/(?P<organization_id>[^\/]+)/webhook/$', BitbucketWebhookEndpoint.as_view()),
+)

--- a/tests/bitbucket/endpoints/__init__.py
+++ b/tests/bitbucket/endpoints/__init__.py
@@ -1,0 +1,1 @@
+from __future__ import absolute_import

--- a/tests/bitbucket/endpoints/test_webhooks.py
+++ b/tests/bitbucket/endpoints/test_webhooks.py
@@ -47,29 +47,29 @@ class WebhookTest(APITestCase):
 
         assert response.status_code == 204
 
-    def test_invalid_signature_event(self):
-        project = self.project  # force creation
-
-        url = '/plugins/bitbucket/organizations/{}/webhook/'.format(
-            project.organization.id,
-        )
-
-        secret = '2d7565c3537847b789d6995dca8d9f84'
-        #todo(maxbittker) this fails because the check isnt implemented
-        OrganizationOption.objects.set_value(
-            organization=project.organization,
-            key='bitbucket:webhook_secret',
-            value=secret,
-        )
-
-        response = self.client.post(
-            path=url,
-            data=PUSH_EVENT_EXAMPLE,
-            content_type='application/json',
-            HTTP_X_EVENT_KEY='repo:push',
-        )
-
-        assert response.status_code == 401
+    #     #todo(maxbittker) this isn't testable yet because the check isnt implemented
+    # def test_invalid_signature_event(self):
+    #     project = self.project  # force creation
+    #
+    #     url = '/plugins/bitbucket/organizations/{}/webhook/'.format(
+    #         project.organization.id,
+    #     )
+    #
+    #     secret = '2d7565c3537847b789d6995dca8d9f84'
+    #     OrganizationOption.objects.set_value(
+    #         organization=project.organization,
+    #         key='bitbucket:webhook_secret',
+    #         value=secret,
+    #     )
+    #
+    #     response = self.client.post(
+    #         path=url,
+    #         data=PUSH_EVENT_EXAMPLE,
+    #         content_type='application/json',
+    #         HTTP_X_EVENT_KEY='repo:push',
+    #     )
+    #
+    #     assert response.status_code == 401
 
 
 class PushEventWebhookTest(APITestCase):

--- a/tests/bitbucket/endpoints/test_webhooks.py
+++ b/tests/bitbucket/endpoints/test_webhooks.py
@@ -3,13 +3,14 @@ from __future__ import absolute_import
 
 from datetime import datetime
 from django.utils import timezone
-from sentry.models import Commit, CommitAuthor, OrganizationOption, Repository
+from sentry.models import Commit, CommitAuthor, Repository
 from sentry.testutils import APITestCase
 
 from sentry_plugins.bitbucket.testutils import PUSH_EVENT_EXAMPLE
 
 BAD_IP = '109.111.111.10'
 BITBUCKET_IP = '104.192.143.10'
+
 
 class WebhookTest(APITestCase):
     def test_get(self):

--- a/tests/bitbucket/endpoints/test_webhooks.py
+++ b/tests/bitbucket/endpoints/test_webhooks.py
@@ -4,12 +4,18 @@ from __future__ import absolute_import
 from datetime import datetime
 from django.utils import timezone
 from sentry.models import Commit, CommitAuthor, Repository
-from sentry.testutils import APITestCase
+from sentry.testutils import APITestCase, TestCase
 
+from sentry_plugins.bitbucket.endpoints.webhook import parse_raw_user
 from sentry_plugins.bitbucket.testutils import PUSH_EVENT_EXAMPLE
 
 BAD_IP = '109.111.111.10'
 BITBUCKET_IP = '104.192.143.10'
+
+
+class UtilityFunctionTest(TestCase):
+    def test_parse_raw_user(self):
+        assert parse_raw_user('Max Bittker <max@getsentry.com>') == 'max@getsentry.com'
 
 
 class WebhookTest(APITestCase):

--- a/tests/bitbucket/endpoints/test_webhooks.py
+++ b/tests/bitbucket/endpoints/test_webhooks.py
@@ -40,7 +40,7 @@ class WebhookTest(APITestCase):
 
         assert response.status_code == 204
 
-    def test_invalid_signature_IP(self):
+    def test_invalid_signature_ip(self):
         project = self.project  # force creation
 
         url = '/plugins/bitbucket/organizations/{}/webhook/'.format(

--- a/tests/bitbucket/endpoints/test_webhooks.py
+++ b/tests/bitbucket/endpoints/test_webhooks.py
@@ -1,13 +1,10 @@
 # -*- coding: utf-8 -*-
 from __future__ import absolute_import
 
-import six
-
 from datetime import datetime
 from django.utils import timezone
 from sentry.models import Commit, CommitAuthor, OrganizationOption, Repository
 from sentry.testutils import APITestCase
-from uuid import uuid4
 
 from sentry_plugins.bitbucket.testutils import PUSH_EVENT_EXAMPLE
 
@@ -118,7 +115,6 @@ class PushEventWebhookTest(APITestCase):
         assert commit.author.email == 'max@getsentry.com'
         assert commit.author.external_id is None
         assert commit.date_added == datetime(2017, 5, 24, 1, 5, 47, tzinfo=timezone.utc)
-
 
     def test_anonymous_lookup(self):
         project = self.project  # force creation

--- a/tests/bitbucket/test_plugin.py
+++ b/tests/bitbucket/test_plugin.py
@@ -33,21 +33,21 @@ class BitbucketPluginTest(PluginTestCase):
         assert self.plugin.get_issue_label(group, 1) == 'Bitbucket-1'
 
     def test_get_issue_url(self):
-        self.plugin.set_option('repo', 'getsentry/sentry', self.project)
+        self.plugin.set_option('repo', 'maxbittker/newsdiffs', self.project)
         group = self.create_group(message='Hello world', culprit='foo.bar')
-        assert self.plugin.get_issue_url(group, 1) == 'https://bitbucket.org/getsentry/sentry/issue/1/'
+        assert self.plugin.get_issue_url(group, 1) == 'https://bitbucket.org/maxbittker/newsdiffs/issue/1/'
 
     def test_is_configured(self):
         assert self.plugin.is_configured(None, self.project) is False
-        self.plugin.set_option('repo', 'getsentry/sentry', self.project)
+        self.plugin.set_option('repo', 'maxbittker/newsdiffs', self.project)
         assert self.plugin.is_configured(None, self.project) is True
 
     @responses.activate
     def test_create_issue(self):
-        responses.add(responses.POST, 'https://api.bitbucket.org/1.0/repositories/getsentry/sentry/issues',
+        responses.add(responses.POST, 'https://api.bitbucket.org/1.0/repositories/maxbittker/newsdiffs/issues',
             body='{"local_id": 1, "title": "Hello world"}')
 
-        self.plugin.set_option('repo', 'getsentry/sentry', self.project)
+        self.plugin.set_option('repo', 'maxbittker/newsdiffs', self.project)
         group = self.create_group(message='Hello world', culprit='foo.bar')
 
         request = self.request.get('/')
@@ -72,12 +72,12 @@ class BitbucketPluginTest(PluginTestCase):
 
     @responses.activate
     def test_link_issue(self):
-        responses.add(responses.GET, 'https://api.bitbucket.org/1.0/repositories/getsentry/sentry/issues/1',
+        responses.add(responses.GET, 'https://api.bitbucket.org/1.0/repositories/maxbittker/newsdiffs/issues/1',
             body='{"local_id": 1, "title": "Hello world"}')
-        responses.add(responses.POST, 'https://api.bitbucket.org/1.0/repositories/getsentry/sentry/issues/1/comments',
+        responses.add(responses.POST, 'https://api.bitbucket.org/1.0/repositories/maxbittker/newsdiffs/issues/1/comments',
             body='{"body": "Hello"}')
 
-        self.plugin.set_option('repo', 'getsentry/sentry', self.project)
+        self.plugin.set_option('repo', 'maxbittker/newsdiffs', self.project)
         group = self.create_group(message='Hello world', culprit='foo.bar')
 
         request = self.request.get('/')

--- a/tests/bitbucket/test_plugin.py
+++ b/tests/bitbucket/test_plugin.py
@@ -7,6 +7,8 @@ from django.contrib.auth.models import AnonymousUser
 from django.test import RequestFactory
 from sentry.plugins.bases.issue2 import PluginError
 from sentry.testutils import PluginTestCase
+from sentry.utils import json
+
 from social_auth.models import UserSocialAuth
 
 from sentry_plugins.bitbucket.plugin import BitbucketPlugin

--- a/tests/bitbucket/test_plugin.py
+++ b/tests/bitbucket/test_plugin.py
@@ -7,7 +7,6 @@ from django.contrib.auth.models import AnonymousUser
 from django.test import RequestFactory
 from sentry.plugins.bases.issue2 import PluginError
 from sentry.testutils import PluginTestCase
-from sentry.utils import json
 
 from social_auth.models import UserSocialAuth
 

--- a/tests/bitbucket/test_provider.py
+++ b/tests/bitbucket/test_provider.py
@@ -1,0 +1,32 @@
+from __future__ import absolute_import
+
+from exam import fixture
+from sentry.models import Repository
+from sentry.testutils import PluginTestCase
+from sentry.utils import json
+
+from sentry_plugins.bitbucket.plugin import BitbucketRepositoryProvider
+from sentry_plugins.bitbucket.testutils import COMPARE_COMMITS_EXAMPLE, GET_LAST_COMMITS_EXAMPLE
+
+
+class BitbucketPluginTest(PluginTestCase):
+    @fixture
+    def provider(self):
+        return BitbucketRepositoryProvider('bitbucket')
+
+    def test_compare_commits(self):
+        repo = Repository.objects.create(
+            provider='bitbucket',
+            name='maxbittker/newsdiffs',
+            organization_id=1,
+        )
+
+        res = self.provider._format_commits(repo, json.loads(COMPARE_COMMITS_EXAMPLE)['values'])
+
+        assert res == [{
+            'author_email': 'max@getsentry.com',
+            'author_name': 'Max Bittker',
+            'message': 'README.md edited online with Bitbucket',
+            'id': 'e18e4e72de0d824edfbe0d73efe34cbd0d01d301',
+            'repository': 'maxbittker/newsdiffs'
+        }]

--- a/tests/bitbucket/test_provider.py
+++ b/tests/bitbucket/test_provider.py
@@ -6,7 +6,7 @@ from sentry.testutils import PluginTestCase
 from sentry.utils import json
 
 from sentry_plugins.bitbucket.plugin import BitbucketRepositoryProvider
-from sentry_plugins.bitbucket.testutils import COMPARE_COMMITS_EXAMPLE, GET_LAST_COMMITS_EXAMPLE
+from sentry_plugins.bitbucket.testutils import COMPARE_COMMITS_EXAMPLE
 
 
 class BitbucketPluginTest(PluginTestCase):

--- a/tests/bitbucket/test_provider.py
+++ b/tests/bitbucket/test_provider.py
@@ -28,5 +28,6 @@ class BitbucketPluginTest(PluginTestCase):
             'author_name': 'Max Bittker',
             'message': 'README.md edited online with Bitbucket',
             'id': 'e18e4e72de0d824edfbe0d73efe34cbd0d01d301',
-            'repository': 'maxbittker/newsdiffs'
+            'repository': 'maxbittker/newsdiffs',
+            'patch_set': None
         }]

--- a/tests/github/endpoints/test_webhooks.py
+++ b/tests/github/endpoints/test_webhooks.py
@@ -26,7 +26,6 @@ class WebhookTest(APITestCase):
 
     def test_unregistered_event(self):
         project = self.project  # force creation
-        print(project.organization.id)
         url = '/plugins/github/organizations/{}/webhook/'.format(
             project.organization.id,
         )


### PR DESCRIPTION
not pretty but basically works 

[ ] documentation 
[ ] moving old api calls to 2.0 (currently uses both 1.0 and 2.0)
[ ] better tests
[ ] defensive username/email parsing
[ ] hook truncates to 5 commits, investigate backfilling (github truncates to 20)

Needs to merge in concert with:
sentry repo PR: https://github.com/getsentry/sentry/pull/5480