### PR TITLE
Don't pass empty string for environment fixes SENTRY-3CN

### DIFF
--- a/src/sentry_plugins/heroku/plugin.py
+++ b/src/sentry_plugins/heroku/plugin.py
@@ -35,7 +35,7 @@ class HerokuReleaseHook(ReleaseHook):
                 project=self.project,
                 key='heroku:environment',
                 default='production',
-            )
+            ) or 'production'
             if repo_project_option:
                 try:
                     repository = Repository.objects.get(


### PR DESCRIPTION
While the default value for `ProjectOption` with key `heroku:environment` is 'production', users can still save the value as an empty string. Because the `DeploySerializer` has `environment` as a required field in the `ReleaseDeploysEndpoint`, this will pass 'production' in the case where the environment value is set to an empty string. 