### PR TITLE
Slack Plugin - Remove unsupported parameter 'parse'

### DIFF
--- a/src/sentry_plugins/slack/plugin.py
+++ b/src/sentry_plugins/slack/plugin.py
@@ -214,7 +214,6 @@ class SlackPlugin(CorePluginMixin, notify.NotificationPlugin):
                 })
 
         payload = {
-            'parse': 'none',
             'attachments': [{
                 'fallback': '[%s] %s' % (project_name, title),
                 'title': title,

--- a/tests/slack/test_plugin.py
+++ b/tests/slack/test_plugin.py
@@ -42,7 +42,6 @@ class SlackPluginTest(PluginTestCase):
         request = responses.calls[0].request
         payload = json.loads(parse_qs(request.body)['payload'][0])
         assert payload == {
-            'parse': 'none',
             'username': 'Sentry',
             'attachments': [
                 {
@@ -85,7 +84,6 @@ class SlackPluginTest(PluginTestCase):
         request = responses.calls[0].request
         payload = json.loads(parse_qs(request.body)['payload'][0])
         assert payload == {
-            'parse': 'none',
             'username': 'Sentry',
             'attachments': [
                 {
@@ -123,7 +121,6 @@ class SlackPluginTest(PluginTestCase):
         request = responses.calls[0].request
         payload = json.loads(parse_qs(request.body)['payload'][0])
         assert payload == {
-            'parse': 'none',
             'username': 'Sentry',
             'attachments': [
                 {


### PR DESCRIPTION
Slack doesn't seem to support the `parse` parameter in the webhook payload. Removing it enables the plugin to work with slack again