### PR TITLE
remove breaking code

### DIFF
--- a/src/sentry_plugins/slack/plugin.py
+++ b/src/sentry_plugins/slack/plugin.py
@@ -235,7 +235,7 @@ class SlackPlugin(CorePluginMixin, notify.NotificationPlugin):
                 {
                     'fallback': '[%s] %s' % (project_name, title),
                     'title': title,
-                    'title_link': self.add_notification_referrer_param(group.get_absolute_url()),
+                    'title_link': group.get_absolute_url(),
                     'color': self.color_for_event(event),
                     'fields': fields,
                 }


### PR DESCRIPTION
Hey. Unless I'm mis-understanding how this feature works, it looks like this single line of code fails because it's not referenced anywhere and breaks the entire plugin. Tested, works fine after removing this line of code.