### PR TITLE
Update VictorOps payload to include details, project, and issue number.

### DIFF
--- a/src/sentry_plugins/victorops/client.py
+++ b/src/sentry_plugins/victorops/client.py
@@ -53,6 +53,9 @@ class VictorOpsClient(object):
                 'timestamp': timestamp,
                 'state_message': state_message,
                 'monitoring_tool': monitoring_tool or self.monitoring_tool,
+                'details': details,
+                'project': project,
+                'issue': issue,
             }
         )
         return self.request(kwargs)

--- a/src/sentry_plugins/victorops/plugin.py
+++ b/src/sentry_plugins/victorops/plugin.py
@@ -82,6 +82,9 @@ class VictorOpsPlugin(CorePluginMixin, NotifyPlugin):
             entity_display_name=event.title,
             state_message=self.build_description(event),
             timestamp=int(event.datetime.strftime('%s')),
+            details=details,
+            project=project.name,
+            issue=issue_id,
         )
 
         assert response['result'] == 'success'


### PR DESCRIPTION
Mutual customer has asked for our help in adding more relevant information to the payload of the alerts sent to VictorOps.  These changes simply add a few extra parameters.