### PR TITLE
feat(amazon_sqs): Add endpoint_url option to amazon_sqs plugin

### DIFF
--- a/src/sentry_plugins/validators.py
+++ b/src/sentry_plugins/validators.py
@@ -1,0 +1,11 @@
+from sentry.plugins.validators import URLValidator
+
+
+def OptionalURLValidator(value, **kwargs):
+    """
+    Validates URLs, but allows for empty strings, unlike the default URL
+    validator.
+    """
+    if not value:
+        return value
+    return URLValidator(value, **kwargs)

--- a/tests/amazon_sqs/test_plugin.py
+++ b/tests/amazon_sqs/test_plugin.py
@@ -28,6 +28,7 @@ class AmazonSQSPluginTest(PluginTestCase):
         self.plugin.set_option(
             'queue_url', 'https://sqs-us-east-1.amazonaws.com/12345678/myqueue', self.project
         )
+        self.plugin.set_option('endpoint_url', 'https://sqs-us-east-1.amazonaws.com', self.project)
 
         group = self.create_group(message='Hello world', culprit='foo.bar')
         event = self.create_event(
@@ -58,6 +59,7 @@ class AmazonSQSPluginTest(PluginTestCase):
             region_name='us-east-1',
             aws_access_key_id='access-key',
             aws_secret_access_key='secret-key',
+            endpoint_url='https://sqs-us-east-1.amazonaws.com',
         )
         mock_client.return_value.send_message.assert_called_once_with(
             QueueUrl='https://sqs-us-east-1.amazonaws.com/12345678/myqueue',

--- a/tests/test_validators.py
+++ b/tests/test_validators.py
@@ -1,0 +1,17 @@
+from __future__ import absolute_import
+
+import pytest
+
+from sentry.exceptions import PluginError
+from sentry.testutils import TestCase
+
+from sentry_plugins.validators import OptionalURLValidator
+
+
+class OptionalURLValidatorTest(TestCase):
+    def test_empty(self):
+        assert OptionalURLValidator('') == ''
+
+    def test_invalid_url(self):
+        with pytest.raises(PluginError):
+            OptionalURLValidator('foj3n3on2')


### PR DESCRIPTION
Without an endpoint_url argument, boto3 sends requests to the production AWS
service's endpoint. This makes it impossible to use Sentry with a mock SQS
service, like localstack.