### PR TITLE
Bumping Gitlab plugin API version to v4

### DIFF
--- a/src/sentry_plugins/gitlab/client.py
+++ b/src/sentry_plugins/gitlab/client.py
@@ -19,7 +19,7 @@ class GitLabClient(object):
         session = build_session()
         try:
             resp = getattr(session, method.lower())(
-                url='{}/api/v3/{}'.format(self.url, path.lstrip('/')),
+                url='{}/api/v4/{}'.format(self.url, path.lstrip('/')),
                 headers=headers,
                 json=data,
                 params=params,
@@ -40,14 +40,11 @@ class GitLabClient(object):
         try:
             return self.request(
                 'GET',
-                '/projects/{}/issues'.format(
+                '/projects/{}/issues/{}'.format(
                     quote(repo, safe=''),
-                ),
-                params={
-                    # XXX(dcramer): this is an undocumented API
-                    'iid': issue_id,
-                }
-            )[0]
+                    issue_id
+                )
+            )
         except IndexError:
             raise ApiError('Issue not found with ID', 404)
 
@@ -58,12 +55,12 @@ class GitLabClient(object):
             data=data,
         )
 
-    def create_note(self, repo, global_issue_id, data):
+    def create_note(self, repo, issue_iid, data):
         return self.request(
             'POST',
             '/projects/{}/issues/{}/notes'.format(
                 quote(repo, safe=''),
-                global_issue_id,
+                issue_iid,
             ),
             data=data,
         )

--- a/src/sentry_plugins/gitlab/plugin.py
+++ b/src/sentry_plugins/gitlab/plugin.py
@@ -125,7 +125,7 @@ class GitLabPlugin(CorePluginMixin, IssuePlugin2):
             try:
                 client.create_note(
                     repo=repo,
-                    global_issue_id=issue['id'],
+                    issue_iid=issue['iid'],
                     data={
                         'body': comment,
                     },
@@ -138,11 +138,11 @@ class GitLabPlugin(CorePluginMixin, IssuePlugin2):
     def get_issue_label(self, group, issue_id, **kwargs):
         return 'GL-{}'.format(issue_id)
 
-    def get_issue_url(self, group, issue_id, **kwargs):
+    def get_issue_url(self, group, issue_iid, **kwargs):
         url = self.get_option('gitlab_url', group.project).rstrip('/')
         repo = self.get_option('gitlab_repo', group.project)
 
-        return '{}/{}/issues/{}'.format(url, repo, issue_id)
+        return '{}/{}/issues/{}'.format(url, repo, issue_iid)
 
     def get_configure_plugin_fields(self, request, project, **kwargs):
         gitlab_token = self.get_option('gitlab_token', project)

--- a/tests/gitlab/test_plugin.py
+++ b/tests/gitlab/test_plugin.py
@@ -50,7 +50,7 @@ class GitLabPluginTest(PluginTestCase):
     def test_create_issue(self):
         responses.add(
             responses.POST,
-            'https://gitlab.com/api/v3/projects/getsentry%2Fsentry/issues',
+            'https://gitlab.com/api/v4/projects/getsentry%2Fsentry/issues',
             body='{"iid": 1, "id": "10"}'
         )
 
@@ -82,13 +82,13 @@ class GitLabPluginTest(PluginTestCase):
     def test_link_issue(self):
         responses.add(
             responses.GET,
-            'https://gitlab.com/api/v3/projects/getsentry%2Fsentry/issues?iid=1',
-            body='[{"iid": 1, "id": "10", "title": "Hello world"}]',
+            'https://gitlab.com/api/v4/projects/getsentry%2Fsentry/issues/1',
+            body='{"iid": 1, "id": "10", "title": "Hello world"}',
             match_querystring=True
         )
         responses.add(
             responses.POST,
-            'https://gitlab.com/api/v3/projects/getsentry%2Fsentry/issues/10/notes',
+            'https://gitlab.com/api/v4/projects/getsentry%2Fsentry/issues/1/notes',
             body='{"body": "Hello"}'
         )
 


### PR DESCRIPTION
On June 22th Gitlab will remove version 3 from their codebase (currently deprecated). This PR bumps the version used by the plugin.