### PR TITLE
Update README.md

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -63,10 +63,9 @@ GitLab
 ------
 
 Go to your project's configuration page (Projects -> [Project] -> Issue Tracking) and select
-GitLab. Enter the required credentials and click save changes.
-
+GitLab. Enter the required credentials and click save changes. In input field `Access Token`
+type `personal access token<https://docs.gitlab.com/ee/user/profile/personal_access_tokens.html>`_
 It's recommended to create a specific user for Sentry with only `Reporter` privileges on your projects.
-
 
 HipChat
 -------


### PR DESCRIPTION
In section `Gitalb` I add information about token, right way to use [personal access tokens](https://docs.gitlab.com/ce/api/README.html#personal-access-tokens), not [access token](https://docs.gitlab.com/ce/api/README.html#oauth2-tokens). If in input texrt field `Access Token` of interface user types `access_token`  instead `Personal access token` he catch error `Unauthorized: either your access token was invalid or you do not have access`