### PR TITLE
fix: Update readme for gitlab personal access token

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -63,7 +63,9 @@ GitLab
 ------
 
 Go to your project's configuration page (Projects -> [Project] -> Issue Tracking) and select
-GitLab. Enter the required credentials and click save changes.
+GitLab. Enter the required credentials (use a `personal access
+token<https://docs.gitlab.com/ee/user/profile/personal_access_tokens.html>`_)
+and click save changes.
 
 It's recommended to create a specific user for Sentry with only `Reporter` privileges on your projects.
 


### PR DESCRIPTION
This is a follow up of https://github.com/getsentry/sentry-plugins/pull/370