### PR TITLE
fix(slack): Correctly encode rules field

### DIFF
--- a/src/sentry_plugins/slack/plugin.py
+++ b/src/sentry_plugins/slack/plugin.py
@@ -181,13 +181,15 @@ class SlackPlugin(CorePluginMixin, notify.NotificationPlugin):
                 # Make sure it's an absolute uri since we're sending this
                 # outside of Sentry into Slack
                 rule_link = absolute_uri(rule_link)
-                rules.append((rule_link, rule.label.encode('utf-8')))
+                rules.append((rule_link, rule.label))
 
             if rules:
+                value = u', '.join(u'<{} | {}>'.format(*r) for r in rules)
+
                 fields.append(
                     {
                         'title': 'Triggered By',
-                        'value': u', '.join(u'<{} | {}>'.format(*r) for r in rules),
+                        'value': value.encode('utf-8'),
                         'short': False,
                     }
                 )


### PR DESCRIPTION
Fixes [SENTRY-6EY](https://sentry.io/share/issue/0110633b1cfa4ea0856f2f44f2caa4cc/). Relates to https://github.com/getsentry/sentry-plugins/pull/346