### PR TITLE
Fix assignees to inherit group members

### DIFF
--- a/src/sentry_plugins/gitlab/client.py
+++ b/src/sentry_plugins/gitlab/client.py
@@ -68,5 +68,5 @@ class GitLabClient(object):
     def list_project_members(self, repo):
         return self.request(
             'GET',
-            '/projects/{}/members'.format(quote(repo, safe='')),
+            '/projects/{}/members/all'.format(quote(repo, safe='')),
         )


### PR DESCRIPTION
As discussed in #399, this pull request should fix the missing gitlab assignee issue 