### PR TITLE
ref(gitlab):Increase member request to 100 results

### DIFF
--- a/src/sentry_plugins/gitlab/client.py
+++ b/src/sentry_plugins/gitlab/client.py
@@ -68,5 +68,5 @@ class GitLabClient(object):
     def list_project_members(self, repo):
         return self.request(
             'GET',
-            '/projects/{}/members'.format(quote(repo, safe='')),
+            '/projects/{}/members?per_page=100'.format(quote(repo, safe='')),
         )


### PR DESCRIPTION
Default is 20. Increase it to 100 so more assignees will show up in the dropdown. 