### PR TITLE
fix(pagerduty) Fix the exception type coming out of pagerduty

### DIFF
--- a/src/sentry_plugins/pagerduty/plugin.py
+++ b/src/sentry_plugins/pagerduty/plugin.py
@@ -1,7 +1,6 @@
 from __future__ import absolute_import
 
 from sentry.plugins.bases.notify import NotifyPlugin
-from sentry_plugins.exceptions import ApiError
 from sentry.utils.http import absolute_uri
 
 from sentry_plugins.base import CorePluginMixin


### PR DESCRIPTION
Instead of letting the ApiError bubble up to sentry catch and reraise a `sentry.exceptions.PluginError` as that is a type that sentry can catch.

Refs getsentry/sentry#10838