### PR TITLE
(gitlab) Show members from the group, not only those who were directly assigned

### DIFF
--- a/src/sentry_plugins/gitlab/client.py
+++ b/src/sentry_plugins/gitlab/client.py
@@ -68,5 +68,5 @@ class GitLabClient(object):
     def list_project_members(self, repo):
         return self.request(
             'GET',
-            '/projects/{}/members?per_page=100'.format(quote(repo, safe='')),
+            '/projects/{}/members/all/?per_page=100'.format(quote(repo, safe='')),
         )


### PR DESCRIPTION
Current:
- members of a group are not available as issue assignee, only users that were directly assigned to project can be selected

Expected:
- all users having permission for a project can be selected as issue assignee

More information on API changes
https://gitlab.com/gitlab-org/gitlab-ce/merge_requests/19748