### PR TITLE
fix(jira): Accomodate versioned autocomplete endpoint

### DIFF
--- a/src/sentry_plugins/jira/plugin.py
+++ b/src/sentry_plugins/jira/plugin.py
@@ -1,6 +1,7 @@
 from __future__ import absolute_import
 
 import logging
+import re
 
 from django.conf import settings
 from django.conf.urls import url
@@ -312,7 +313,7 @@ class JiraPlugin(CorePluginMixin, IssuePlugin2):
 
             jira_client = self.get_jira_client(group.project)
 
-            is_user_api = '/rest/api/latest/user/' in jira_url
+            is_user_api = re.search('/rest/api/(latest|[0-9])/user/', jira_url)
 
             is_user_picker = '/rest/api/1.0/users/picker' in jira_url
 


### PR DESCRIPTION
### Issue
When a versioned API is used for the Jira autocomplete integration, sentry behaves as if the endpoint is to the XML version of the API, and errors with `AttributeError: 'SequenceApiResponse' object has no attribute 'xml'`.

### Background
For the project I'm working in, when trying to use the Jira integration in Sentry, the Reporter field performs an ajax request to autocomplete users in jira. The request is to `https://sentry.tpastream.com/api/0/issues/422/plugins/jira/autocomplete?jira_url=https%3A%2F%2Ftpastream.atlassian.net%2Frest%2Fapi%2F2%2Fuser%2Fsearch%3Fquery%3D&autocomplete_query=&autocomplete_field=reporter`.

Decoded, the jira url is `https://tpastream.atlassian.net/rest/api/2/user/search?query=&autocomplete_query=&autocomplete_field=reporter` This url is fine and well (returning a 200 with JSON from Jira as expected). However, because the version is 2 (...`rest/api/2/user`...) it does not match the string `rest/api/latest/user` (https://github.com/getsentry/sentry-plugins/compare/master...craigmichaelmartin:patch-1#diff-826bb174b7633c7e83fe19c71bc73104L315) and so Sentry behaves as if the url is to the XML version of the API, which results in an error.

### Proposed Fix
This PR adds logic to ensure using a versioned api for the json autocomplete endpoint is still understood to be part of the json api (and not xml).

### Alternative Fixes
Rather than accommodating versioned apis, force all urls to use `latest` and not specific versions; ie, if the jira_url was ...`rest/api/latest/user`... instead of ...`rest/api/2/user` the match on `rest/api/latest/user` (as is) would be sufficient.