### PR TITLE
Convert Asana GIDs to strings

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,6 +27,7 @@ env:
     - SENTRY_SKIP_BACKEND_VALIDATION=1
     - TRAVIS_NODE_VERSION=10.16.3
     - YARN_VERSION="1.17.3"
+    - NODE_OPTIONS=--max-old-space-size=4096
 
 matrix:
   include:

--- a/src/sentry_plugins/asana/client.py
+++ b/src/sentry_plugins/asana/client.py
@@ -1,6 +1,7 @@
 from __future__ import absolute_import
 
 from sentry_plugins.client import AuthApiClient
+from six import text_type
 
 
 class AsanaClient(AuthApiClient):
@@ -14,12 +15,12 @@ class AsanaClient(AuthApiClient):
         return self.get("/tasks/%s" % issue_id)
 
     def create_issue(self, workspace, data):
-        asana_data = {"name": data["title"], "notes": data["description"], "workspace": workspace}
+        asana_data = {"name": data["title"], "notes": data["description"], "workspace": text_type(workspace)}
         if data.get("project"):
-            asana_data["projects"] = [data["project"]]
+            asana_data["projects"] = [text_type(data["project"])]
 
         if data.get("assignee"):
-            asana_data["assignee"] = data["assignee"]
+            asana_data["assignee"] = text_type(data["assignee"])
 
         return self.post("/tasks", data={"data": asana_data})
 

--- a/src/sentry_plugins/jira/plugin.py
+++ b/src/sentry_plugins/jira/plugin.py
@@ -634,7 +634,7 @@ class JiraPlugin(CorePluginMixin, IssuePlugin2):
 
         return True
 
-    def post_process(self, group, event, is_new, is_sample, **kwargs):
+    def post_process(self, group, event, is_new, **kwargs):
         if not self.should_create(group, event, is_new):
             return
 

--- a/tests/asana/test_plugin.py
+++ b/tests/asana/test_plugin.py
@@ -50,7 +50,7 @@ class AsanaPluginTest(PluginTestCase):
             json={"data": {"name": "Hello world!", "notes": "Fix this.", "id": 1}},
         )
 
-        self.plugin.set_option("workspace", 12345678, self.project)
+        self.plugin.set_option("workspace", "12345678", self.project)
         group = self.create_group(message="Hello world", culprit="foo.bar")
 
         request = self.request.get("/")
@@ -68,7 +68,7 @@ class AsanaPluginTest(PluginTestCase):
         assert self.plugin.create_issue(request, group, form_data) == 1
         request = responses.calls[0].request
         payload = json.loads(request.body)
-        assert payload == {"data": {"notes": "Fix this.", "name": "Hello", "workspace": 12345678}}
+        assert payload == {"data": {"notes": "Fix this.", "name": "Hello", "workspace": "12345678"}}
 
     @responses.activate
     def test_link_issue(self):


### PR DESCRIPTION
Convert GIDs to strings for Asana API compatibility.

See: https://forum.asana.com/t/asana-is-moving-to-string-ids-updated-with-revised-timeline/29340
