### PR TITLE
replace asana id with new gid

### DIFF
--- a/src/sentry_plugins/asana/plugin.py
+++ b/src/sentry_plugins/asana/plugin.py
@@ -41,7 +41,7 @@ class AsanaPlugin(CorePluginMixin, IssuePlugin2):
         return False
 
     def get_workspace_choices(self, workspaces):
-        return [(w["id"], w["name"]) for w in workspaces["data"]]
+        return [(w["gid"], w["name"]) for w in workspaces["data"]]
 
     def get_new_issue_fields(self, request, group, event, **kwargs):
         fields = super(AsanaPlugin, self).get_new_issue_fields(request, group, event, **kwargs)
@@ -147,7 +147,7 @@ class AsanaPlugin(CorePluginMixin, IssuePlugin2):
         comment = form_data.get("comment")
         if comment:
             try:
-                client.create_comment(issue["id"], {"text": comment})
+                client.create_comment(issue["gid"], {"text": comment})
             except Exception as e:
                 self.raise_error(e, identity=client.auth)
 
@@ -194,13 +194,14 @@ class AsanaPlugin(CorePluginMixin, IssuePlugin2):
                 "be able to change it back to the current configuration "
                 "unless a teammate grants you access to the workspace in Asana."
             )
+        print ("workspace", workspaces)
         return [
             {
                 "name": "workspace",
                 "label": "Workspace",
                 "type": "select",
                 "choices": workspace_choices,
-                "default": workspace or workspaces["data"][0]["id"],
+                "default": workspace or workspaces["data"][0]["gid"],
                 "help": helptext,
             }
         ]
@@ -226,7 +227,7 @@ class AsanaPlugin(CorePluginMixin, IssuePlugin2):
             )
         else:
             results = [
-                {"text": "(#%s) %s" % (i["id"], i["name"]), "id": i["id"]}
+                {"text": "(#%s) %s" % (i["gid"], i["name"]), "id": i["gid"]}
                 for i in response.get("data", [])
             ]
 

--- a/src/sentry_plugins/asana/plugin.py
+++ b/src/sentry_plugins/asana/plugin.py
@@ -194,7 +194,6 @@ class AsanaPlugin(CorePluginMixin, IssuePlugin2):
                 "be able to change it back to the current configuration "
                 "unless a teammate grants you access to the workspace in Asana."
             )
-        print ("workspace", workspaces)
         return [
             {
                 "name": "workspace",

--- a/tests/asana/test_plugin.py
+++ b/tests/asana/test_plugin.py
@@ -75,7 +75,7 @@ class AsanaPluginTest(PluginTestCase):
         responses.add(
             responses.GET,
             "https://app.asana.com/api/1.0/tasks/1",
-            json={"data": {"id": 1, "name": "Hello", "notes": "Fix this."}},
+            json={"data": {"gid": 1, "name": "Hello", "notes": "Fix this."}},
         )
         responses.add(
             responses.POST,


### PR DESCRIPTION
Asana is in the process of deprecating the numerical field id and replacing it with a string field gid. This has broken our Asana integration because the id field is now gone. More details here: https://asana.com/developers/news/string-ids